### PR TITLE
feat: add postmortem PDF export

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.11.0",
-    "react-table": "^7.8.0"
+    "react-table": "^7.8.0",
+    "jspdf": "^2.5.1",
+    "html2canvas": "^1.4.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import IncidentsTab from './IncidentsTab';
 import ActionsTab from './ActionsTab';
 import MetricsTab from './MetricsTab';
+import PostmortemDetail from './PostmortemDetail';
 
 const tabs = ['Incidents', 'Postmortems', 'Actions', 'Metrics'] as const;
 type Tab = typeof tabs[number];
@@ -24,7 +25,15 @@ export default function Dashboard() {
       </nav>
       <div>
         {active === 'Incidents' && <IncidentsTab />}
-        {active === 'Postmortems' && <div>Postmortems content coming soon...</div>}
+        {active === 'Postmortems' && (
+          <PostmortemDetail
+            postmortem={{
+              title: 'Database outage',
+              incidentId: 'INC-001',
+              summary: 'Root cause and remediation details for the outage.',
+            }}
+          />
+        )}
         {active === 'Actions' && <ActionsTab />}
         {active === 'Metrics' && <MetricsTab />}
       </div>

--- a/frontend/src/components/PostmortemDetail.tsx
+++ b/frontend/src/components/PostmortemDetail.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
+
+type Postmortem = {
+  title: string;
+  incidentId: string;
+  summary: string;
+};
+
+interface Props {
+  postmortem: Postmortem;
+}
+
+export default function PostmortemDetail({ postmortem }: Props) {
+  const exportPdf = async () => {
+    const doc = new jsPDF();
+    doc.text(postmortem.title, 10, 10);
+    doc.text(`Incident ID: ${postmortem.incidentId}`, 10, 20);
+    doc.text(postmortem.summary, 10, 30);
+
+    const element = document.getElementById('postmortem-content');
+    if (element) {
+      const canvas = await html2canvas(element);
+      const imgData = canvas.toDataURL('image/png');
+      const imgProps = doc.getImageProperties(imgData);
+      const pdfWidth = doc.internal.pageSize.getWidth();
+      const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+      doc.addImage(imgData, 'PNG', 10, 40, pdfWidth - 20, pdfHeight);
+    }
+
+    doc.save(`${postmortem.incidentId}.pdf`);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div id="postmortem-content" className="p-4 border rounded">
+        <h2 className="text-xl font-semibold">{postmortem.title}</h2>
+        <p>Incident ID: {postmortem.incidentId}</p>
+        <p>{postmortem.summary}</p>
+      </div>
+      <button
+        onClick={exportPdf}
+        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+      >
+        Export to PDF
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -1,0 +1,2 @@
+declare module 'jspdf';
+declare module 'html2canvas';


### PR DESCRIPTION
## Summary
- add jspdf and html2canvas dependencies
- render PostmortemDetail with Export to PDF button
- declare external module typings for jsPDF and html2canvas

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68af45b48c1c8329ab03881477ddcdf0