### PR TITLE
feat: apply console-inspired Tailwind theme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,10 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" />
     <title>Aftermath Dashboard</title>
   </head>
-  <body>
+  <body class="bg-neutral-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100 font-sans">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script>
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('dark');
+      }
+    </script>
   </body>
 </html>

--- a/frontend/src/components/ActionsTab.tsx
+++ b/frontend/src/components/ActionsTab.tsx
@@ -18,7 +18,7 @@ const data: StatusCount[] = actions.reduce<StatusCount[]>((acc, action) => {
 
 export default function ActionsTab() {
   return (
-    <div className="w-full h-64">
+    <div className="w-full h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
       <ResponsiveContainer>
         <PieChart>
           <Pie data={data} dataKey="value" nameKey="status" fill="#82ca9d" label />

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -12,11 +12,15 @@ export default function Dashboard() {
 
   return (
     <div className="p-4">
-      <nav className="border-b mb-4 flex space-x-4">
+      <nav className="border-b border-neutral-200 dark:border-neutral-700 mb-4 flex space-x-4 overflow-x-auto">
         {tabs.map((tab) => (
           <button
             key={tab}
-            className={`pb-2 ${active === tab ? 'border-b-2 border-blue-500 font-semibold' : 'text-gray-500'}`}
+            className={`pb-2 -mb-px transition-colors ${
+              active === tab
+                ? 'border-b-2 border-accent text-accent font-medium'
+                : 'text-neutral-600 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200'
+            }`}
             onClick={() => setActive(tab)}
           >
             {tab}

--- a/frontend/src/components/IncidentsTab.tsx
+++ b/frontend/src/components/IncidentsTab.tsx
@@ -18,7 +18,7 @@ const data: SeverityCount[] = incidents.reduce<SeverityCount[]>((acc, incident) 
 
 export default function IncidentsTab() {
   return (
-    <div className="w-full h-64">
+    <div className="w-full h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
       <ResponsiveContainer>
         <BarChart data={data}>
           <XAxis dataKey="severity" />

--- a/frontend/src/components/MetricsTab.tsx
+++ b/frontend/src/components/MetricsTab.tsx
@@ -3,7 +3,7 @@ import { mttrData } from '../mock/metrics';
 
 export default function MetricsTab() {
   return (
-    <div className="w-full h-64">
+    <div className="w-full h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
       <ResponsiveContainer>
         <LineChart data={mttrData}>
           <XAxis dataKey="date" />

--- a/frontend/src/components/PostmortemDetail.tsx
+++ b/frontend/src/components/PostmortemDetail.tsx
@@ -34,14 +34,17 @@ export default function PostmortemDetail({ postmortem }: Props) {
 
   return (
     <div className="space-y-4">
-      <div id="postmortem-content" className="p-4 border rounded">
+      <div
+        id="postmortem-content"
+        className="p-4 border border-neutral-200 dark:border-neutral-700 rounded bg-white dark:bg-neutral-800"
+      >
         <h2 className="text-xl font-semibold">{postmortem.title}</h2>
         <p>Incident ID: {postmortem.incidentId}</p>
         <p>{postmortem.summary}</p>
       </div>
       <button
         onClick={exportPdf}
-        className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark transition-colors"
       >
         Export to PDF
       </button>

--- a/frontend/src/components/PostmortemTable.tsx
+++ b/frontend/src/components/PostmortemTable.tsx
@@ -78,11 +78,11 @@ export default function PostmortemTable() {
 
   return (
     <div className="space-y-4">
-      <div className="flex space-x-4">
+      <div className="flex flex-wrap gap-4">
         <select
           value={severityFilter}
           onChange={(e) => setSeverityFilter(e.target.value)}
-          className="border rounded p-1"
+          className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
         >
           <option value="All">All Severities</option>
           <option value="Low">Low</option>
@@ -93,23 +93,27 @@ export default function PostmortemTable() {
           type="date"
           value={startDate}
           onChange={(e) => setStartDate(e.target.value)}
-          className="border rounded p-1"
+          className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
         />
         <input
           type="date"
           value={endDate}
           onChange={(e) => setEndDate(e.target.value)}
-          className="border rounded p-1"
+          className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
         />
       </div>
-      <table {...getTableProps()} className="min-w-full border">
+      <div className="overflow-x-auto">
+        <table
+          {...getTableProps()}
+          className="min-w-full border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 rounded"
+        >
         <thead>
           {headerGroups.map((headerGroup) => (
             <tr {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map((column) => (
                 <th
                   {...column.getHeaderProps(column.getSortByToggleProps())}
-                  className="border-b p-2 text-left cursor-pointer select-none"
+                  className="border-b border-neutral-300 dark:border-neutral-700 p-2 text-left cursor-pointer select-none bg-neutral-100 dark:bg-neutral-700"
                 >
                   {column.render('Header')}
                   <span>
@@ -128,9 +132,15 @@ export default function PostmortemTable() {
           {rows.map((row) => {
             prepareRow(row);
             return (
-              <tr {...row.getRowProps()} className="hover:bg-gray-50">
+              <tr
+                {...row.getRowProps()}
+                className="hover:bg-neutral-100 dark:hover:bg-neutral-700"
+              >
                 {row.cells.map((cell) => (
-                  <td {...cell.getCellProps()} className="p-2 border-b">
+                  <td
+                    {...cell.getCellProps()}
+                    className="p-2 border-b border-neutral-200 dark:border-neutral-700"
+                  >
                     {cell.render('Cell')}
                   </td>
                 ))}
@@ -139,6 +149,7 @@ export default function PostmortemTable() {
           })}
         </tbody>
       </table>
+      </div>
     </div>
   );
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,7 +1,35 @@
 export default {
+  darkMode: 'class',
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        neutral: {
+          50: '#f9fafb',
+          100: '#f3f4f6',
+          200: '#e5e7eb',
+          300: '#d1d5db',
+          400: '#9ca3af',
+          500: '#6b7280',
+          600: '#4b5563',
+          700: '#374151',
+          800: '#1f2937',
+          900: '#111827',
+        },
+        primary: {
+          DEFAULT: '#2563eb',
+          dark: '#1e3a8a',
+        },
+        accent: {
+          DEFAULT: '#ff9900',
+          dark: '#b46900',
+        },
+      },
+      fontFamily: {
+        sans: ['Roboto', 'Helvetica Neue', 'Arial', 'sans-serif'],
+        mono: ['Roboto Mono', 'monospace'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- extend Tailwind with neutral palette, console fonts, and accent colors
- style navigation, cards, tables, and buttons to match the new theme
- enable dark mode detection and responsive card layouts

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*
- `npm run build` *(fails: Cannot find module 'react/jsx-runtime', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68af467b773c8329aaf88fd5a9b8bcf8