### PR TITLE
feat: add TypeScript express backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+build/

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.17",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,18 @@
+import express from 'express';
+import incidents from './routes/incidents';
+import postmortems from './routes/postmortems';
+import actions from './routes/actions';
+import metrics from './routes/metrics';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use('/incidents', incidents);
+app.use('/postmortems', postmortems);
+app.use('/actions', actions);
+app.use('/metrics', metrics);
+
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Server listening on port ${port}`);
+});

--- a/backend/src/routes/actions.ts
+++ b/backend/src/routes/actions.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({
+    actions: [
+      { id: 1, description: 'Restart database service' },
+      { id: 2, description: 'Update firewall rules' }
+    ]
+  });
+});
+
+export default router;

--- a/backend/src/routes/incidents.ts
+++ b/backend/src/routes/incidents.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({
+    incidents: [
+      { id: 1, title: 'Database outage' },
+      { id: 2, title: 'Network issue' }
+    ]
+  });
+});
+
+export default router;

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({
+    metrics: {
+      uptime: 99.9,
+      incidentsLastWeek: 5
+    }
+  });
+});
+
+export default router;

--- a/backend/src/routes/postmortems.ts
+++ b/backend/src/routes/postmortems.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({
+    postmortems: [
+      { id: 1, incidentId: 1, summary: 'Resolved database outage' },
+      { id: 2, incidentId: 2, summary: 'Fixed network configuration' }
+    ]
+  });
+});
+
+export default router;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Express server with TypeScript
- add mock routes for incidents, postmortems, actions, and metrics
- provide dev and build scripts

## Testing
- `npm run build` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68af478dca1483298090f4cc494f93ca