### PR TITLE
feat: add JWT auth middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,10 +12,14 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "bcryptjs": "^2.4.3",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
+    "@types/bcryptjs": "^2.4.2",
+    "@types/jsonwebtoken": "^9.0.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.0"
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,14 +3,19 @@ import incidents from './routes/incidents';
 import postmortems from './routes/postmortems';
 import actions from './routes/actions';
 import metrics from './routes/metrics';
+import authRoutes from './routes/auth';
+import authMiddleware from './middleware/auth';
 
 const app = express();
 const port = process.env.PORT || 3000;
 
-app.use('/incidents', incidents);
-app.use('/postmortems', postmortems);
-app.use('/actions', actions);
-app.use('/metrics', metrics);
+app.use(express.json());
+
+app.use('/auth', authRoutes);
+app.use('/incidents', authMiddleware, incidents);
+app.use('/postmortems', authMiddleware, postmortems);
+app.use('/actions', authMiddleware, actions);
+app.use('/metrics', authMiddleware, metrics);
 
 app.listen(port, () => {
   // eslint-disable-next-line no-console

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import jwt from 'jsonwebtoken';
+
+export interface AuthRequest extends Request {
+  user?: string | jwt.JwtPayload;
+}
+
+export default function auth(req: AuthRequest, res: Response, next: NextFunction) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader) {
+    return res.status(401).json({ message: 'No token provided' });
+  }
+
+  const [, token] = authHeader.split(' ');
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import jwt from 'jsonwebtoken';
+import bcrypt from 'bcryptjs';
+
+const router = Router();
+
+// Example in-memory user. In a real app, replace with DB lookup.
+const users = [
+  {
+    id: 1,
+    username: 'admin',
+    passwordHash: bcrypt.hashSync('password', 10)
+  }
+];
+
+router.post('/login', async (req, res) => {
+  const { username, password } = req.body;
+  const user = users.find(u => u.username === username);
+
+  if (!user) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const valid = await bcrypt.compare(password, user.passwordHash);
+  if (!valid) {
+    return res.status(401).json({ message: 'Invalid credentials' });
+  }
+
+  const token = jwt.sign({ id: user.id, username: user.username }, process.env.JWT_SECRET || 'secret', {
+    expiresIn: '1h'
+  });
+
+  res.json({ token });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add jsonwebtoken and bcryptjs dependencies
- provide /auth/login route issuing JWT tokens
- verify JWT on protected routes via auth middleware

## Testing
- `npm install --omit=dev` *(fails: 403 Forbidden for @types/bcryptjs)*
- `npm run build` *(fails: sh: 1: tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af48df016083298fed4adc8edd9979