### PR TITLE
Add validation and global error handling

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "express": "^4.18.2",
     "bcryptjs": "^2.4.3",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import actions from './routes/actions';
 import metrics from './routes/metrics';
 import authRoutes from './routes/auth';
 import authMiddleware from './middleware/auth';
+import errorHandler from './middleware/errorHandler';
 
 const app = express();
 const port = process.env.PORT || 3000;
@@ -16,6 +17,8 @@ app.use('/incidents', authMiddleware, incidents);
 app.use('/postmortems', authMiddleware, postmortems);
 app.use('/actions', authMiddleware, actions);
 app.use('/metrics', authMiddleware, metrics);
+
+app.use(errorHandler);
 
 app.listen(port, () => {
   // eslint-disable-next-line no-console

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodError } from 'zod';
+
+const errorHandler = (
+  err: any,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+
+  if (err instanceof ZodError) {
+    res.status(400).json({ message: 'Validation error', errors: err.errors });
+    return;
+  }
+
+  const status = err.status || 500;
+  const message = err.message || 'Internal Server Error';
+  res.status(status).json({ message });
+};
+
+export default errorHandler;

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,18 @@
+import { AnyZodObject } from 'zod';
+import { Request, Response, NextFunction } from 'express';
+
+const validate = (
+  schema: AnyZodObject,
+  property: 'body' | 'params' | 'query' = 'body'
+) => {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    try {
+      schema.parse(req[property]);
+      next();
+    } catch (err) {
+      next(err);
+    }
+  };
+};
+
+export default validate;

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -1,6 +1,8 @@
 import { Router } from 'express';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
+import { z } from 'zod';
+import validate from '../middleware/validate';
 
 const router = Router();
 
@@ -13,7 +15,12 @@ const users = [
   }
 ];
 
-router.post('/login', async (req, res) => {
+const loginSchema = z.object({
+  username: z.string(),
+  password: z.string()
+});
+
+router.post('/login', validate(loginSchema), async (req, res) => {
   const { username, password } = req.body;
   const user = users.find(u => u.username === username);
 


### PR DESCRIPTION
## Summary
- add zod-based validation middleware for bodies/params
- introduce centralized error handler middleware
- wire validation and error handling into auth routes and server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'express' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68af4a89eb9483298a31c3807225ec12