### PR TITLE
Add mock integrations and factory

### DIFF
--- a/integrations/package.json
+++ b/integrations/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "integrations",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "test": "echo 'No tests'"
+  }
+}

--- a/integrations/src/index.ts
+++ b/integrations/src/index.ts
@@ -1,0 +1,25 @@
+import { Integration } from './types';
+import { ServiceNowIntegration } from './serviceNow';
+import { PagerDutyIntegration } from './pagerDuty';
+import { JiraIntegration } from './jira';
+
+export function createIntegrations(): Record<string, Integration> {
+  const integrations: Record<string, Integration> = {};
+
+  if (process.env.SERVICENOW_TOKEN) {
+    integrations.servicenow = new ServiceNowIntegration();
+  }
+
+  if (process.env.PAGERDUTY_TOKEN) {
+    integrations.pagerduty = new PagerDutyIntegration();
+  }
+
+  if (process.env.JIRA_TOKEN) {
+    integrations.jira = new JiraIntegration();
+  }
+
+  return integrations;
+}
+
+export { ServiceNowIntegration, PagerDutyIntegration, JiraIntegration };
+export * from './types';

--- a/integrations/src/jira.ts
+++ b/integrations/src/jira.ts
@@ -1,0 +1,24 @@
+import { Integration, Incident, Action, ActionResponse } from './types';
+
+export class JiraIntegration implements Integration {
+  private endpoint: string;
+  private token: string;
+
+  constructor() {
+    this.endpoint = process.env.JIRA_ENDPOINT ?? 'https://your-jira-instance.atlassian.net';
+    this.token = process.env.JIRA_TOKEN ?? 'dummy-token';
+  }
+
+  async fetchIncident(id: string): Promise<Incident> {
+    // Mock API call
+    console.log(`Jira fetchIncident called with id=${id} using ${this.endpoint}`);
+    return { id, source: 'Jira' };
+  }
+
+  async createAction(item: Action): Promise<ActionResponse> {
+    // Mock API call
+    console.log('Jira createAction called with', item);
+    return { success: true, message: 'Jira action created' };
+  }
+}
+

--- a/integrations/src/pagerDuty.ts
+++ b/integrations/src/pagerDuty.ts
@@ -1,0 +1,24 @@
+import { Integration, Incident, Action, ActionResponse } from './types';
+
+export class PagerDutyIntegration implements Integration {
+  private endpoint: string;
+  private token: string;
+
+  constructor() {
+    this.endpoint = process.env.PAGERDUTY_ENDPOINT ?? 'https://api.pagerduty.com';
+    this.token = process.env.PAGERDUTY_TOKEN ?? 'dummy-token';
+  }
+
+  async fetchIncident(id: string): Promise<Incident> {
+    // Mock API call
+    console.log(`PagerDuty fetchIncident called with id=${id} using ${this.endpoint}`);
+    return { id, source: 'PagerDuty' };
+  }
+
+  async createAction(item: Action): Promise<ActionResponse> {
+    // Mock API call
+    console.log('PagerDuty createAction called with', item);
+    return { success: true, message: 'PagerDuty action created' };
+  }
+}
+

--- a/integrations/src/serviceNow.ts
+++ b/integrations/src/serviceNow.ts
@@ -1,0 +1,24 @@
+import { Integration, Incident, Action, ActionResponse } from './types';
+
+export class ServiceNowIntegration implements Integration {
+  private endpoint: string;
+  private token: string;
+
+  constructor() {
+    this.endpoint = process.env.SERVICENOW_ENDPOINT ?? 'https://example.service-now.com';
+    this.token = process.env.SERVICENOW_TOKEN ?? 'dummy-token';
+  }
+
+  async fetchIncident(id: string): Promise<Incident> {
+    // Mock API call
+    console.log(`ServiceNow fetchIncident called with id=${id} using ${this.endpoint}`);
+    return { id, source: 'ServiceNow' };
+  }
+
+  async createAction(item: Action): Promise<ActionResponse> {
+    // Mock API call
+    console.log('ServiceNow createAction called with', item);
+    return { success: true, message: 'ServiceNow action created' };
+  }
+}
+

--- a/integrations/src/types.ts
+++ b/integrations/src/types.ts
@@ -1,0 +1,22 @@
+export interface Incident {
+  id: string;
+  title?: string;
+  [key: string]: any;
+}
+
+export interface Action {
+  type: string;
+  [key: string]: any;
+}
+
+export interface ActionResponse {
+  success: boolean;
+  message?: string;
+  [key: string]: any;
+}
+
+export interface Integration {
+  fetchIncident(id: string): Promise<Incident>;
+  createAction(item: Action): Promise<ActionResponse>;
+}
+


### PR DESCRIPTION
## Summary
- define common Integration interface and basic domain types
- implement ServiceNow, PagerDuty, and Jira mock connectors
- add factory to load integrations from environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af4b619c2483298c495113660e8f1a