### PR TITLE
Add environment template and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,14 @@
-# Example environment variables for Aftermath project
-API_KEY=your_api_key_here
-DATABASE_URL=postgres://user:password@localhost:5432/aftermath
+# JWT configuration
+JWT_SECRET=your-jwt-secret
+
+# API URLs
+BACKEND_URL=http://localhost:3000
+FRONTEND_URL=http://localhost:5173
+
+# Connector credentials
+JIRA_ENDPOINT=https://your-jira-instance.atlassian.net
+JIRA_TOKEN=your-jira-api-token
+PAGERDUTY_ENDPOINT=https://api.pagerduty.com
+PAGERDUTY_TOKEN=your-pagerduty-token
+SERVICENOW_ENDPOINT=https://example.service-now.com
+SERVICENOW_TOKEN=your-servicenow-token

--- a/README.md
+++ b/README.md
@@ -14,3 +14,47 @@ Additional files:
 
 - `.env.example` – Example environment variables for APIs
 - `docker-compose.yml` – Docker Compose configuration
+
+## Installation
+
+1. **Install dependencies**
+
+   ```bash
+   cd backend && npm install
+   cd ../frontend && npm install
+   cd ../integrations && npm install
+   ```
+
+2. **Environment variables**
+
+   Copy the example file and update values as needed:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+## Running locally
+
+### Backend
+
+```bash
+cd backend
+npm run dev
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm run dev
+```
+
+## Configuring integrations
+
+Set the connector credentials and API URLs in your `.env` file:
+
+- `JIRA_ENDPOINT` and `JIRA_TOKEN`
+- `PAGERDUTY_ENDPOINT` and `PAGERDUTY_TOKEN`
+- `SERVICENOW_ENDPOINT` and `SERVICENOW_TOKEN`
+
+The `JWT_SECRET` key is also required for authentication.


### PR DESCRIPTION
## Summary
- Add comprehensive `.env.example` with placeholders for JWT secret, API URLs, and connector credentials
- Document dependency installation, local running instructions, and integration configuration in README

## Testing
- ⚠️ `npm test` (backend) - missing script
- ⚠️ `npm install` (backend) - 403 Forbidden fetching packages
- ⚠️ `npm run build` (backend) - TypeScript errors due to missing modules
- ⚠️ `npm test` (frontend) - missing script
- ⚠️ `npm install` (frontend) - 403 Forbidden fetching packages
- ⚠️ `npm run build` (frontend) - TypeScript errors due to missing modules
- ✅ `npm test` (integrations)

------
https://chatgpt.com/codex/tasks/task_e_68af4f0433a8832994a78b8c07cc408e