### PR TITLE
Ensure backend port is configured via environment

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -8,7 +8,7 @@ import authMiddleware from './middleware/auth';
 import errorHandler from './middleware/errorHandler';
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = Number(process.env.PORT);
 
 app.use(express.json());
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: "3.8"
 services:
   backend:
     build: ./backend
+    environment:
+      - PORT=5000
     ports:
       - "5000:5000"
   frontend:


### PR DESCRIPTION
## Summary
- remove fallback port and rely on `process.env.PORT`
- set `PORT` env var for backend service in docker-compose

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbcryptjs)*
- `docker compose build` *(fails: command not found)*
- `docker compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af512f712c8329b3290237a4d9e9ed