### PR TITLE
Add Docker build setup for backend and frontend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 5000
+CMD ["node","dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,16 @@ version: "3.8"
 
 services:
   backend:
-    build: ./backend
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
     environment:
       - PORT=5000
     ports:
       - "5000:5000"
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
     ports:
-      - "3000:3000"
+      - "3000:80"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:20-alpine as build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Serve stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx","-g","daemon off;"]


### PR DESCRIPTION
## Summary
- add backend Dockerfile to build TypeScript and run Node server
- add frontend multi-stage Dockerfile to build with Vite and serve via nginx
- ignore node_modules and dist in Docker contexts
- update docker-compose to reference Dockerfiles and serve frontend on port 3000

## Testing
- `npm install` *(fails: 403 Forbidden fetching @types/bcryptjs)*
- `npm run build` *(fails: missing module declarations in frontend and backend)*

------
https://chatgpt.com/codex/tasks/task_e_68af51eb6fe48329972bbc70cdb940af