### PR TITLE
Add integration and deployment docs with contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to Aftermath
+
+Thanks for your interest in contributing! This guide outlines how to participate in the project.
+
+## Coding Standards
+
+- Use TypeScript for Node and React code.
+- Maintain a consistent code style using Prettier defaults and existing project patterns.
+- Write clear commit messages and keep changes focused.
+
+## Pull Request Flow
+
+1. Fork the repository and create a feature branch.
+2. Make your changes with clear commits.
+3. Ensure documentation and tests are updated.
+4. Open a pull request describing the motivation and changes.
+5. Address review feedback before merging.
+
+## Testing Requirements
+
+Run the available test suites for any packages you modify. For example:
+
+```bash
+cd integrations && npm test
+```
+
+Pull requests should only be merged when the relevant tests pass.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ Set the connector credentials and API URLs in your `.env` file:
 - `SERVICENOW_ENDPOINT` and `SERVICENOW_TOKEN`
 
 The `JWT_SECRET` key is also required for authentication.
+
+## Documentation
+
+- [Integration connectors](docs/integrations.md)
+- [Deployment guide](docs/deployment.md)
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on coding standards, pull requests, and testing.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,41 @@
+# Deployment
+
+This guide covers running Aftermath using Docker or Kubernetes.
+
+## Docker Compose
+
+Use the provided `docker-compose.yml` to start the application locally:
+
+```bash
+docker compose up --build
+```
+
+The command builds images for the backend, frontend, and integrations services and starts them with sensible defaults.
+
+## Kubernetes
+
+A minimal deployment can be achieved by containerizing the services and applying Kubernetes manifests. Below is an example for the backend:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: aftermath-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: aftermath-backend
+  template:
+    metadata:
+      labels:
+        app: aftermath-backend
+    spec:
+      containers:
+        - name: backend
+          image: your-registry/aftermath-backend:latest
+          ports:
+            - containerPort: 3000
+```
+
+Expose the service using a `Service` or `Ingress` resource as appropriate for your cluster.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,40 @@
+# Integration Connectors
+
+This document outlines conventions for building connectors in the `integrations` package and provides a minimal example.
+
+## General Guidelines
+
+- Each connector lives in `integrations/src` and is written in TypeScript.
+- Implement the `Integration` interface which requires `fetchIncident` and `createAction` methods.
+- Configuration such as API endpoints and tokens should be read from environment variables.
+- Keep network calls asynchronous and return plain JavaScript objects.
+
+## Sample Connector
+
+```ts
+import { Integration, Incident, Action, ActionResponse } from './types';
+
+export class ExampleIntegration implements Integration {
+  private endpoint: string;
+  private token: string;
+
+  constructor() {
+    this.endpoint = process.env.EXAMPLE_ENDPOINT ?? 'https://api.example.com';
+    this.token = process.env.EXAMPLE_TOKEN ?? '';
+  }
+
+  async fetchIncident(id: string): Promise<Incident> {
+    // Replace with real API request
+    console.log(`fetchIncident called with id=${id}`);
+    return { id, source: 'Example' };
+  }
+
+  async createAction(item: Action): Promise<ActionResponse> {
+    // Replace with real API request
+    console.log('createAction called with', item);
+    return { success: true, message: 'Action created' };
+  }
+}
+```
+
+Use this structure as a template when adding new connectors.


### PR DESCRIPTION
## Summary
- add integration connector conventions with sample TypeScript template
- document Docker Compose and Kubernetes deployment options
- introduce contributing guide and link docs from README

## Testing
- `cd integrations && npm test`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af52d7a4b08329824a78a5f81d846c