### PR TITLE
Require JWT secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 # JWT configuration
+# Required secret for signing JSON Web Tokens
 JWT_SECRET=your-jwt-secret
 
 # API URLs

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,12 @@ import errorHandler from './middleware/errorHandler';
 const app = express();
 const port = Number(process.env.PORT);
 
+if (!process.env.JWT_SECRET) {
+  // eslint-disable-next-line no-console
+  console.error('JWT_SECRET is not defined');
+  process.exit(1);
+}
+
 app.use(express.json());
 
 app.use('/auth', authRoutes);

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -14,7 +14,7 @@ export default function auth(req: AuthRequest, res: Response, next: NextFunction
   const [, token] = authHeader.split(' ');
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const decoded = jwt.verify(token, process.env.JWT_SECRET!);
     req.user = decoded;
     next();
   } catch (err) {

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -33,7 +33,7 @@ router.post('/login', validate(loginSchema), async (req, res) => {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
 
-  const token = jwt.sign({ id: user.id, username: user.username }, process.env.JWT_SECRET || 'secret', {
+  const token = jwt.sign({ id: user.id, username: user.username }, process.env.JWT_SECRET!, {
     expiresIn: '1h'
   });
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,6 +2,8 @@
 
 This guide covers running Aftermath using Docker or Kubernetes.
 
+The backend requires a `JWT_SECRET` environment variable for signing JSON Web Tokens. The server exits during startup if it is missing.
+
 ## Docker Compose
 
 Use the provided `docker-compose.yml` to start the application locally:
@@ -10,7 +12,15 @@ Use the provided `docker-compose.yml` to start the application locally:
 docker compose up --build
 ```
 
-The command builds images for the backend, frontend, and integrations services and starts them with sensible defaults.
+The command builds images for the backend, frontend, and integrations services and starts them with sensible defaults. Ensure the `JWT_SECRET` variable is supplied to the backend service, for example:
+
+```yaml
+services:
+  backend:
+    environment:
+      - PORT=5000
+      - JWT_SECRET=replace-with-secure-value
+```
 
 ## Kubernetes
 
@@ -34,6 +44,9 @@ spec:
       containers:
         - name: backend
           image: your-registry/aftermath-backend:latest
+          env:
+            - name: JWT_SECRET
+              value: replace-with-secure-value
           ports:
             - containerPort: 3000
 ```


### PR DESCRIPTION
## Summary
- remove fallback JWT secret and rely on required `JWT_SECRET`
- exit backend startup if `JWT_SECRET` is missing
- document the required env var in `.env.example` and deployment guide

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'express' and other packages)*

------
https://chatgpt.com/codex/tasks/task_e_68af548b043c832989f8ca63bd98df11