### PR TITLE
Add integration tests with Jest

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,19 @@
+name: Integration Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: integrations
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm test

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -4,6 +4,28 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "test": "echo 'No tests'"
+    "test": "jest --coverage"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "jest": "^29.6.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.0"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "collectCoverageFrom": [
+      "src/**/*.ts",
+      "!src/index.ts"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 80,
+        "functions": 80,
+        "lines": 80,
+        "statements": 80
+      }
+    }
   }
 }

--- a/integrations/src/__tests__/jira.test.ts
+++ b/integrations/src/__tests__/jira.test.ts
@@ -1,0 +1,30 @@
+import { JiraIntegration } from '../jira';
+
+describe('JiraIntegration', () => {
+  let integration: JiraIntegration;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    integration = new JiraIntegration();
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('fetchIncident returns expected incident and logs call', async () => {
+    const result = await integration.fetchIncident('789');
+    expect(result).toEqual({ id: '789', source: 'Jira' });
+    expect(logSpy).toHaveBeenCalledWith(
+      'Jira fetchIncident called with id=789 using https://your-jira-instance.atlassian.net'
+    );
+  });
+
+  it('createAction returns success and logs call', async () => {
+    const action = { type: 'test-action' };
+    const result = await integration.createAction(action);
+    expect(result).toEqual({ success: true, message: 'Jira action created' });
+    expect(logSpy).toHaveBeenCalledWith('Jira createAction called with', action);
+  });
+});

--- a/integrations/src/__tests__/pagerDuty.test.ts
+++ b/integrations/src/__tests__/pagerDuty.test.ts
@@ -1,0 +1,30 @@
+import { PagerDutyIntegration } from '../pagerDuty';
+
+describe('PagerDutyIntegration', () => {
+  let integration: PagerDutyIntegration;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    integration = new PagerDutyIntegration();
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('fetchIncident returns expected incident and logs call', async () => {
+    const result = await integration.fetchIncident('456');
+    expect(result).toEqual({ id: '456', source: 'PagerDuty' });
+    expect(logSpy).toHaveBeenCalledWith(
+      'PagerDuty fetchIncident called with id=456 using https://api.pagerduty.com'
+    );
+  });
+
+  it('createAction returns success and logs call', async () => {
+    const action = { type: 'test-action' };
+    const result = await integration.createAction(action);
+    expect(result).toEqual({ success: true, message: 'PagerDuty action created' });
+    expect(logSpy).toHaveBeenCalledWith('PagerDuty createAction called with', action);
+  });
+});

--- a/integrations/src/__tests__/serviceNow.test.ts
+++ b/integrations/src/__tests__/serviceNow.test.ts
@@ -1,0 +1,30 @@
+import { ServiceNowIntegration } from '../serviceNow';
+
+describe('ServiceNowIntegration', () => {
+  let integration: ServiceNowIntegration;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    integration = new ServiceNowIntegration();
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('fetchIncident returns expected incident and logs call', async () => {
+    const result = await integration.fetchIncident('123');
+    expect(result).toEqual({ id: '123', source: 'ServiceNow' });
+    expect(logSpy).toHaveBeenCalledWith(
+      'ServiceNow fetchIncident called with id=123 using https://example.service-now.com'
+    );
+  });
+
+  it('createAction returns success and logs call', async () => {
+    const action = { type: 'test-action' };
+    const result = await integration.createAction(action);
+    expect(result).toEqual({ success: true, message: 'ServiceNow action created' });
+    expect(logSpy).toHaveBeenCalledWith('ServiceNow createAction called with', action);
+  });
+});

--- a/integrations/tsconfig.json
+++ b/integrations/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
## Summary
- configure Jest and coverage enforcement for integrations
- add unit tests for ServiceNow, PagerDuty, and Jira integrations
- run integration tests in CI

## Testing
- `npm test` *(fails: jest not found; dependencies unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68af5580fbe88329a4841a0b438780ed