### PR TITLE
feat: add plugin system

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,15 @@
+# Creating Plugins
+
+Plugins let you extend Aftermath without modifying core code. To add a plugin:
+
+1. Create a new `.ts` file inside the `plugins/` directory.
+2. Export a default object that implements the `Plugin` interface described in `plugins/README.md`.
+3. Inside the `register` function, attach any values or functions to the provided registry object.
+4. Run the loader to verify your plugin registers correctly:
+
+```bash
+# from the repository root
+backend/node_modules/.bin/ts-node plugins/index.ts
+```
+
+The example plugin `plugins/examplePlugin.ts` registers a `greet` function. When the loader runs, it outputs the message returned by this function.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,23 @@
+# Plugin Interface
+
+Plugins extend Aftermath by exporting a default object that matches the `Plugin` interface. Each plugin is placed in this directory and will be loaded automatically.
+
+```ts
+export interface Plugin {
+  /** Unique name used to identify the plugin */
+  name: string;
+  /** Called by the loader to let the plugin register itself */
+  register: (registry: PluginRegistry) => void;
+}
+
+export type PluginRegistry = Record<string, unknown>;
+```
+
+The `registry` object is shared between all plugins. Plugins can attach any values or functions to it for the application to consume.
+
+## Creating a Plugin
+1. Create a new `.ts` file in this folder.
+2. Export a default object that implements `Plugin`.
+3. Attach your features to the provided registry inside the `register` function.
+
+See `examplePlugin.ts` for a working example.

--- a/plugins/examplePlugin.ts
+++ b/plugins/examplePlugin.ts
@@ -1,0 +1,10 @@
+import type { Plugin } from './index';
+
+const examplePlugin: Plugin = {
+  name: 'example',
+  register(registry) {
+    registry['greet'] = () => 'Hello from example plugin';
+  },
+};
+
+export default examplePlugin;

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,0 +1,36 @@
+import { readdir } from 'fs/promises';
+import path from 'path';
+
+export interface Plugin {
+  name: string;
+  register: (registry: PluginRegistry) => void;
+}
+
+export type PluginRegistry = Record<string, unknown>;
+
+export async function loadPlugins(registry: PluginRegistry = {}): Promise<PluginRegistry> {
+  const files = await readdir(__dirname);
+  for (const file of files) {
+    if (file === 'index.ts' || file === 'index.js') continue;
+    if (!file.endsWith('.ts') && !file.endsWith('.js')) continue;
+    const modulePath = path.join(__dirname, file);
+    const { default: plugin } = await import(modulePath);
+    if (plugin && typeof plugin.register === 'function') {
+      plugin.register(registry);
+    }
+  }
+  return registry;
+}
+
+if (require.main === module) {
+  loadPlugins().then((registry) => {
+    // Demonstrate usage of registered values/functions
+    for (const [key, value] of Object.entries(registry)) {
+      if (typeof value === 'function') {
+        console.log(`${key}:`, (value as () => unknown)());
+      } else {
+        console.log(`${key}:`, value);
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- document a plugin interface for extending Aftermath
- add dynamic plugin loader with example plugin
- explain plugin creation steps in new docs

## Testing
- `node backend/node_modules/ts-node/dist/bin.js --compiler-options '{"module":"commonjs"}' plugins/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af56addbc88329b2eb4e8fed73f545