### PR TITLE
Add Helm charts for backend and frontend services

### DIFF
--- a/deploy/helm/backend/Chart.yaml
+++ b/deploy/helm/backend/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: backend
+version: 0.1.0
+appVersion: "1.0.0"

--- a/deploy/helm/backend/templates/deployment.yaml
+++ b/deploy/helm/backend/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-backend
+  labels:
+    app: {{ .Release.Name }}-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-backend
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-backend
+    spec:
+      containers:
+        - name: backend
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          env:
+            - name: PORT
+              value: "{{ .Values.env.port }}"
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-backend-secret
+                  key: jwt
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/deploy/helm/backend/templates/secret.yaml
+++ b/deploy/helm/backend/templates/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-backend-secret
+type: Opaque
+stringData:
+  jwt: {{ .Values.secret.jwt | quote }}

--- a/deploy/helm/backend/templates/service.yaml
+++ b/deploy/helm/backend/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-backend
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Release.Name }}-backend
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/deploy/helm/backend/values.yaml
+++ b/deploy/helm/backend/values.yaml
@@ -1,0 +1,9 @@
+image:
+  repository: backend
+  tag: latest
+service:
+  port: 5000
+env:
+  port: 5000
+secret:
+  jwt: ""

--- a/deploy/helm/frontend/Chart.yaml
+++ b/deploy/helm/frontend/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: frontend
+version: 0.1.0
+appVersion: "1.0.0"

--- a/deploy/helm/frontend/templates/deployment.yaml
+++ b/deploy/helm/frontend/templates/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-frontend
+  labels:
+    app: {{ .Release.Name }}-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-frontend
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          env:
+            - name: VITE_API_URL
+              value: {{ .Values.env.apiUrl | quote }}
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/deploy/helm/frontend/templates/service.yaml
+++ b/deploy/helm/frontend/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Release.Name }}-frontend
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}

--- a/deploy/helm/frontend/values.yaml
+++ b/deploy/helm/frontend/values.yaml
@@ -1,0 +1,7 @@
+image:
+  repository: frontend
+  tag: latest
+service:
+  port: 80
+env:
+  apiUrl: "http://localhost:5000"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -52,3 +52,21 @@ spec:
 ```
 
 Expose the service using a `Service` or `Ingress` resource as appropriate for your cluster.
+
+## Helm
+
+Helm charts for the backend and frontend are available under `deploy/helm`.
+
+Install the backend, providing the JWT secret:
+
+```bash
+helm install backend deploy/helm/backend --set secret.jwt=replace-with-secure-value
+```
+
+Install the frontend and set the API URL for the backend service:
+
+```bash
+helm install frontend deploy/helm/frontend --set env.apiUrl=http://backend:5000
+```
+
+Use `--set` or a custom values file to override image tags, environment variables, and service ports.


### PR DESCRIPTION
## Summary
- add Helm charts for backend and frontend deployments
- parameterize service ports, env vars, and secrets
- document Helm installation steps

## Testing
- `npm run build` (backend) *(fails: Cannot find module 'zod')*
- `npm install` (backend) *(fails: 403 Forbidden for zod)*
- `npm run build` (frontend)
- `helm lint deploy/helm/backend` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af57c723608329929765aca7344838