### PR TITLE
feat: add configurable port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Server configuration
+PORT=5000
+
 # JWT configuration
 # Required secret for signing JSON Web Tokens
 JWT_SECRET=your-jwt-secret

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ Additional files:
    cp .env.example .env
    ```
 
+   Key variables:
+
+   - `PORT` – backend server port (default: 5000)
+   - `JWT_SECRET` – secret for signing JSON Web Tokens
+
 ## Running locally
 
 ### Backend

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,7 +9,7 @@ import errorHandler from './middleware/errorHandler';
 import logger from './middleware/logger';
 
 const app = express();
-const port = Number(process.env.PORT);
+const port = Number(process.env.PORT) || 5000;
 
 if (!process.env.JWT_SECRET) {
   // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary
- allow backend port configuration via `PORT` with default 5000
- document `PORT` variable and add to `.env.example`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af5e0e53688329b9a97fb5c51a321c