### PR TITLE
feat: add timeline event aggregation with slack integration

### DIFF
--- a/integrations/src/__tests__/pagerDuty.test.ts
+++ b/integrations/src/__tests__/pagerDuty.test.ts
@@ -27,4 +27,20 @@ describe('PagerDutyIntegration', () => {
     expect(result).toEqual({ success: true, message: 'PagerDuty action created' });
     expect(logSpy).toHaveBeenCalledWith('PagerDuty createAction called with', action);
   });
+
+  it('fetchEvents returns timeline events and logs call', async () => {
+    const start = new Date('2023-01-01T00:00:00Z');
+    const end = new Date('2023-01-02T00:00:00Z');
+    const result = await integration.fetchEvents(start, end);
+    expect(result).toEqual([
+      {
+        source: 'PagerDuty',
+        timestamp: start.toISOString(),
+        description: 'PagerDuty event',
+      },
+    ]);
+    expect(logSpy).toHaveBeenCalledWith(
+      `PagerDuty fetchEvents called with start=${start.toISOString()} end=${end.toISOString()} using https://api.pagerduty.com`
+    );
+  });
 });

--- a/integrations/src/__tests__/serviceNow.test.ts
+++ b/integrations/src/__tests__/serviceNow.test.ts
@@ -27,4 +27,20 @@ describe('ServiceNowIntegration', () => {
     expect(result).toEqual({ success: true, message: 'ServiceNow action created' });
     expect(logSpy).toHaveBeenCalledWith('ServiceNow createAction called with', action);
   });
+
+  it('fetchEvents returns timeline events and logs call', async () => {
+    const start = new Date('2023-01-01T00:00:00Z');
+    const end = new Date('2023-01-02T00:00:00Z');
+    const result = await integration.fetchEvents(start, end);
+    expect(result).toEqual([
+      {
+        source: 'ServiceNow',
+        timestamp: start.toISOString(),
+        description: 'ServiceNow event',
+      },
+    ]);
+    expect(logSpy).toHaveBeenCalledWith(
+      `ServiceNow fetchEvents called with start=${start.toISOString()} end=${end.toISOString()} using https://example.service-now.com`
+    );
+  });
 });

--- a/integrations/src/__tests__/slack.test.ts
+++ b/integrations/src/__tests__/slack.test.ts
@@ -1,11 +1,11 @@
-import { JiraIntegration } from '../jira';
+import { SlackIntegration } from '../slack';
 
-describe('JiraIntegration', () => {
-  let integration: JiraIntegration;
+describe('SlackIntegration', () => {
+  let integration: SlackIntegration;
   let logSpy: jest.SpyInstance;
 
   beforeEach(() => {
-    integration = new JiraIntegration();
+    integration = new SlackIntegration();
     logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
@@ -14,18 +14,18 @@ describe('JiraIntegration', () => {
   });
 
   it('fetchIncident returns expected incident and logs call', async () => {
-    const result = await integration.fetchIncident('789');
-    expect(result).toEqual({ id: '789', source: 'Jira' });
+    const result = await integration.fetchIncident('999');
+    expect(result).toEqual({ id: '999', source: 'Slack' });
     expect(logSpy).toHaveBeenCalledWith(
-      'Jira fetchIncident called with id=789 using https://your-jira-instance.atlassian.net'
+      'Slack fetchIncident called with id=999 using https://slack.com/api'
     );
   });
 
   it('createAction returns success and logs call', async () => {
     const action = { type: 'test-action' };
     const result = await integration.createAction(action);
-    expect(result).toEqual({ success: true, message: 'Jira action created' });
-    expect(logSpy).toHaveBeenCalledWith('Jira createAction called with', action);
+    expect(result).toEqual({ success: true, message: 'Slack action created' });
+    expect(logSpy).toHaveBeenCalledWith('Slack createAction called with', action);
   });
 
   it('fetchEvents returns timeline events and logs call', async () => {
@@ -34,13 +34,13 @@ describe('JiraIntegration', () => {
     const result = await integration.fetchEvents(start, end);
     expect(result).toEqual([
       {
-        source: 'Jira',
+        source: 'Slack',
         timestamp: start.toISOString(),
-        description: 'Jira event',
+        description: 'Slack event',
       },
     ]);
     expect(logSpy).toHaveBeenCalledWith(
-      `Jira fetchEvents called with start=${start.toISOString()} end=${end.toISOString()} using https://your-jira-instance.atlassian.net`
+      `Slack fetchEvents called with start=${start.toISOString()} end=${end.toISOString()} using https://slack.com/api`
     );
   });
 });

--- a/integrations/src/__tests__/timeline.test.ts
+++ b/integrations/src/__tests__/timeline.test.ts
@@ -1,0 +1,43 @@
+import { collectTimelineEvents } from '../timeline';
+import { Integration, Incident, Action, ActionResponse, TimelineEvent } from '../types';
+
+class MockIntegration implements Integration {
+  constructor(private name: string, private offset: number) {}
+  async fetchIncident(id: string): Promise<Incident> {
+    return { id };
+  }
+  async createAction(item: Action): Promise<ActionResponse> {
+    return { success: true };
+  }
+  async fetchEvents(start: Date, end: Date): Promise<TimelineEvent[]> {
+    return [
+      {
+        source: this.name,
+        timestamp: new Date(start.getTime() + this.offset).toISOString(),
+        description: `${this.name} event`,
+      },
+    ];
+  }
+}
+
+describe('collectTimelineEvents', () => {
+  it('aggregates and sorts events', async () => {
+    const start = new Date('2023-01-01T00:00:00Z');
+    const end = new Date('2023-01-02T00:00:00Z');
+    const a = new MockIntegration('A', 2000);
+    const b = new MockIntegration('B', 1000);
+    const events = await collectTimelineEvents(start, end, { a, b });
+    expect(events).toEqual([
+      {
+        source: 'B',
+        timestamp: new Date(start.getTime() + 1000).toISOString(),
+        description: 'B event',
+      },
+      {
+        source: 'A',
+        timestamp: new Date(start.getTime() + 2000).toISOString(),
+        description: 'A event',
+      },
+    ]);
+  });
+});

--- a/integrations/src/index.ts
+++ b/integrations/src/index.ts
@@ -2,6 +2,7 @@ import { Integration } from './types';
 import { ServiceNowIntegration } from './serviceNow';
 import { PagerDutyIntegration } from './pagerDuty';
 import { JiraIntegration } from './jira';
+import { SlackIntegration } from './slack';
 
 export function createIntegrations(): Record<string, Integration> {
   const integrations: Record<string, Integration> = {};
@@ -18,8 +19,12 @@ export function createIntegrations(): Record<string, Integration> {
     integrations.jira = new JiraIntegration();
   }
 
+  if (process.env.SLACK_TOKEN) {
+    integrations.slack = new SlackIntegration();
+  }
+
   return integrations;
 }
 
-export { ServiceNowIntegration, PagerDutyIntegration, JiraIntegration };
+export { ServiceNowIntegration, PagerDutyIntegration, JiraIntegration, SlackIntegration };
 export * from './types';

--- a/integrations/src/jira.ts
+++ b/integrations/src/jira.ts
@@ -1,4 +1,4 @@
-import { Integration, Incident, Action, ActionResponse } from './types';
+import { Integration, Incident, Action, ActionResponse, TimelineEvent } from './types';
 
 export class JiraIntegration implements Integration {
   private endpoint: string;
@@ -19,6 +19,20 @@ export class JiraIntegration implements Integration {
     // Mock API call
     console.log('Jira createAction called with', item);
     return { success: true, message: 'Jira action created' };
+  }
+
+  async fetchEvents(start: Date, end: Date): Promise<TimelineEvent[]> {
+    // Mock API call
+    console.log(
+      `Jira fetchEvents called with start=${start.toISOString()} end=${end.toISOString()} using ${this.endpoint}`
+    );
+    return [
+      {
+        source: 'Jira',
+        timestamp: start.toISOString(),
+        description: 'Jira event',
+      },
+    ];
   }
 }
 

--- a/integrations/src/pagerDuty.ts
+++ b/integrations/src/pagerDuty.ts
@@ -1,4 +1,4 @@
-import { Integration, Incident, Action, ActionResponse } from './types';
+import { Integration, Incident, Action, ActionResponse, TimelineEvent } from './types';
 
 export class PagerDutyIntegration implements Integration {
   private endpoint: string;
@@ -19,6 +19,20 @@ export class PagerDutyIntegration implements Integration {
     // Mock API call
     console.log('PagerDuty createAction called with', item);
     return { success: true, message: 'PagerDuty action created' };
+  }
+
+  async fetchEvents(start: Date, end: Date): Promise<TimelineEvent[]> {
+    // Mock API call
+    console.log(
+      `PagerDuty fetchEvents called with start=${start.toISOString()} end=${end.toISOString()} using ${this.endpoint}`
+    );
+    return [
+      {
+        source: 'PagerDuty',
+        timestamp: start.toISOString(),
+        description: 'PagerDuty event',
+      },
+    ];
   }
 }
 

--- a/integrations/src/serviceNow.ts
+++ b/integrations/src/serviceNow.ts
@@ -1,4 +1,4 @@
-import { Integration, Incident, Action, ActionResponse } from './types';
+import { Integration, Incident, Action, ActionResponse, TimelineEvent } from './types';
 
 export class ServiceNowIntegration implements Integration {
   private endpoint: string;
@@ -19,6 +19,20 @@ export class ServiceNowIntegration implements Integration {
     // Mock API call
     console.log('ServiceNow createAction called with', item);
     return { success: true, message: 'ServiceNow action created' };
+  }
+
+  async fetchEvents(start: Date, end: Date): Promise<TimelineEvent[]> {
+    // Mock API call
+    console.log(
+      `ServiceNow fetchEvents called with start=${start.toISOString()} end=${end.toISOString()} using ${this.endpoint}`
+    );
+    return [
+      {
+        source: 'ServiceNow',
+        timestamp: start.toISOString(),
+        description: 'ServiceNow event',
+      },
+    ];
   }
 }
 

--- a/integrations/src/slack.ts
+++ b/integrations/src/slack.ts
@@ -1,0 +1,37 @@
+import { Integration, Incident, Action, ActionResponse, TimelineEvent } from './types';
+
+export class SlackIntegration implements Integration {
+  private endpoint: string;
+  private token: string;
+
+  constructor() {
+    this.endpoint = process.env.SLACK_ENDPOINT ?? 'https://slack.com/api';
+    this.token = process.env.SLACK_TOKEN ?? 'dummy-token';
+  }
+
+  async fetchIncident(id: string): Promise<Incident> {
+    // Mock API call
+    console.log(`Slack fetchIncident called with id=${id} using ${this.endpoint}`);
+    return { id, source: 'Slack' };
+  }
+
+  async createAction(item: Action): Promise<ActionResponse> {
+    // Mock API call
+    console.log('Slack createAction called with', item);
+    return { success: true, message: 'Slack action created' };
+  }
+
+  async fetchEvents(start: Date, end: Date): Promise<TimelineEvent[]> {
+    // Mock API call
+    console.log(
+      `Slack fetchEvents called with start=${start.toISOString()} end=${end.toISOString()} using ${this.endpoint}`
+    );
+    return [
+      {
+        source: 'Slack',
+        timestamp: start.toISOString(),
+        description: 'Slack event',
+      },
+    ];
+  }
+}

--- a/integrations/src/timeline.ts
+++ b/integrations/src/timeline.ts
@@ -1,0 +1,18 @@
+import { TimelineEvent, Integration } from './types';
+import { createIntegrations } from './index';
+
+export async function collectTimelineEvents(
+  start: Date,
+  end: Date,
+  integrations: Record<string, Integration> = createIntegrations()
+): Promise<TimelineEvent[]> {
+  const events = await Promise.all(
+    Object.values(integrations).map((integration) => integration.fetchEvents(start, end))
+  );
+
+  return events
+    .flat()
+    .sort(
+      (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+    );
+}

--- a/integrations/src/types.ts
+++ b/integrations/src/types.ts
@@ -15,8 +15,16 @@ export interface ActionResponse {
   [key: string]: any;
 }
 
+export interface TimelineEvent {
+  source: string;
+  timestamp: string;
+  description: string;
+  [key: string]: any;
+}
+
 export interface Integration {
   fetchIncident(id: string): Promise<Incident>;
   createAction(item: Action): Promise<ActionResponse>;
+  fetchEvents(start: Date, end: Date): Promise<TimelineEvent[]>;
 }
 


### PR DESCRIPTION
## Summary
- extend integration types with TimelineEvent interface and fetchEvents API
- implement Slack integration and add fetchEvents support across providers
- aggregate timeline events from all integrations

## Testing
- `npm test --prefix integrations` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6055903483299b77a0b372e699ba