### PR TITLE
feat: add review agenda and remediation actions

### DIFF
--- a/frontend/src/api/remediations.ts
+++ b/frontend/src/api/remediations.ts
@@ -1,0 +1,55 @@
+export interface AgendaNotes {
+  well: string;
+  wrong: string;
+  lucky: string;
+}
+
+export interface Remediation {
+  id: string;
+  provider: string;
+  description: string;
+  url: string;
+}
+
+const AGENDA_KEY = 'review_agenda';
+const ACTIONS_KEY = 'remediation_actions';
+
+export function loadAgenda(): AgendaNotes {
+  const raw = localStorage.getItem(AGENDA_KEY);
+  return raw ? JSON.parse(raw) : { well: '', wrong: '', lucky: '' };
+}
+
+export function saveAgenda(notes: AgendaNotes): void {
+  localStorage.setItem(AGENDA_KEY, JSON.stringify(notes));
+}
+
+export function loadActions(): Remediation[] {
+  const raw = localStorage.getItem(ACTIONS_KEY);
+  return raw ? JSON.parse(raw) : [];
+}
+
+function saveActions(actions: Remediation[]): void {
+  localStorage.setItem(ACTIONS_KEY, JSON.stringify(actions));
+}
+
+export async function createAction(
+  description: string,
+  provider: 'jira' | 'servicenow'
+): Promise<Remediation> {
+  const res = await fetch('/api/actions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ description, provider }),
+  });
+  const data = await res.json();
+  const action: Remediation = {
+    id: data.id,
+    url: data.url,
+    description,
+    provider,
+  };
+  const actions = loadActions();
+  actions.push(action);
+  saveActions(actions);
+  return action;
+}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -6,8 +6,18 @@ import PostmortemDetail, { Postmortem } from './PostmortemDetail';
 import PostmortemTable from './PostmortemTable';
 import TimelineTab from './TimelineTab';
 import CollaborationTab from './CollaborationTab';
+import ReviewAgenda from './ReviewAgenda';
+import RemediationActions from './RemediationActions';
 
-const tabs = ['Incidents', 'Postmortems', 'Actions', 'Metrics', 'Timeline', 'Collaboration'] as const;
+const tabs = [
+  'Incidents',
+  'Postmortems',
+  'Actions',
+  'Metrics',
+  'Timeline',
+  'Collaboration',
+  'Review',
+] as const;
 type Tab = typeof tabs[number];
 
 export default function Dashboard() {
@@ -46,6 +56,12 @@ export default function Dashboard() {
         {active === 'Metrics' && <MetricsTab />}
         {active === 'Timeline' && <TimelineTab />}
         {active === 'Collaboration' && <CollaborationTab />}
+        {active === 'Review' && (
+          <div className="space-y-4">
+            <ReviewAgenda />
+            <RemediationActions />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/RemediationActions.tsx
+++ b/frontend/src/components/RemediationActions.tsx
@@ -1,0 +1,71 @@
+import { FormEvent, useEffect, useState } from 'react';
+import { createAction, loadActions, Remediation } from '../api/remediations';
+
+export default function RemediationActions() {
+  const [description, setDescription] = useState('');
+  const [provider, setProvider] = useState<'jira' | 'servicenow'>('jira');
+  const [actions, setActions] = useState<Remediation[]>([]);
+
+  useEffect(() => {
+    setActions(loadActions());
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!description) return;
+    try {
+      const action = await createAction(description, provider);
+      setActions((prev) => [...prev, action]);
+      setDescription('');
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Remediation Actions</h2>
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Describe follow-up action"
+          className="w-full border p-2 rounded"
+        />
+        <select
+          value={provider}
+          onChange={(e) => setProvider(e.target.value as 'jira' | 'servicenow')}
+          className="border p-2 rounded"
+        >
+          <option value="jira">JIRA</option>
+          <option value="servicenow">ServiceNow</option>
+        </select>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-primary text-white rounded"
+        >
+          Create Action
+        </button>
+      </form>
+      {actions.length > 0 && (
+        <ul className="space-y-1">
+          {actions.map((a) => (
+            <li key={a.id}>
+              {a.description} -{' '}
+              <a
+                href={a.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-primary underline"
+              >
+                {a.id}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ReviewAgenda.tsx
+++ b/frontend/src/components/ReviewAgenda.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { AgendaNotes, loadAgenda, saveAgenda } from '../api/remediations';
+
+export default function ReviewAgenda() {
+  const [notes, setNotes] = useState<AgendaNotes>({
+    well: '',
+    wrong: '',
+    lucky: '',
+  });
+
+  useEffect(() => {
+    setNotes(loadAgenda());
+  }, []);
+
+  const handleChange = (field: keyof AgendaNotes, value: string) => {
+    const next = { ...notes, [field]: value };
+    setNotes(next);
+    saveAgenda(next);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">Review Agenda</h2>
+      <div className="space-y-2">
+        <label className="block font-medium">What went well?</label>
+        <textarea
+          value={notes.well}
+          onChange={(e) => handleChange('well', e.target.value)}
+          className="w-full border p-2 rounded"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="block font-medium">What went wrong?</label>
+        <textarea
+          value={notes.wrong}
+          onChange={(e) => handleChange('wrong', e.target.value)}
+          className="w-full border p-2 rounded"
+        />
+      </div>
+      <div className="space-y-2">
+        <label className="block font-medium">Where did we get lucky?</label>
+        <textarea
+          value={notes.lucky}
+          onChange={(e) => handleChange('lucky', e.target.value)}
+          className="w-full border p-2 rounded"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add local storage api for review agendas and remediation action tickets
- create ReviewAgenda and RemediationActions components
- integrate agenda and actions into new Review tab on dashboard

## Testing
- `npm test` (fails: jest not found)
- `cd integrations && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af656292ac8329be9e04931f865561