### PR TITLE
feat: expand metrics reporting

### DIFF
--- a/backend/src/routes/actions.ts
+++ b/backend/src/routes/actions.ts
@@ -1,13 +1,11 @@
 import { Router } from 'express';
+import { actions } from '../storage';
 
 const router = Router();
 
 router.get('/', (_req, res) => {
   res.json({
-    actions: [
-      { id: 1, description: 'Restart database service' },
-      { id: 2, description: 'Update firewall rules' }
-    ]
+    actions
   });
 });
 

--- a/backend/src/routes/incidents.ts
+++ b/backend/src/routes/incidents.ts
@@ -1,13 +1,11 @@
 import { Router } from 'express';
+import { incidents } from '../storage';
 
 const router = Router();
 
 router.get('/', (_req, res) => {
   res.json({
-    incidents: [
-      { id: 1, title: 'Database outage' },
-      { id: 2, title: 'Network issue' }
-    ]
+    incidents
   });
 });
 

--- a/backend/src/routes/metrics.ts
+++ b/backend/src/routes/metrics.ts
@@ -1,12 +1,94 @@
 import { Router } from 'express';
+import { incidents, actions, postmortems } from '../storage';
 
 const router = Router();
 
+const msToHours = (ms: number): number => ms / (1000 * 60 * 60);
+
 router.get('/', (_req, res) => {
+  const totalIncidents = incidents.length;
+  const incidentsWithPostmortems = incidents.filter((incident) =>
+    postmortems.some((pm) => pm.incidentId === incident.id)
+  );
+  const percentPostmortemsCompleted = totalIncidents
+    ? (incidentsWithPostmortems.length / totalIncidents) * 100
+    : 0;
+
+  const totalActions = actions.length;
+  const closedActions = actions.filter((action) => action.status === 'closed');
+  const percentActionsClosed = totalActions
+    ? (closedActions.length / totalActions) * 100
+    : 0;
+
+  const timesToPostmortem = incidentsWithPostmortems.map((incident) => {
+    const pm = postmortems.find((p) => p.incidentId === incident.id)!;
+    return pm.completedAt.getTime() - incident.createdAt.getTime();
+  });
+  const avgTimeToPostmortem = timesToPostmortem.length
+    ? timesToPostmortem.reduce((a, b) => a + b, 0) / timesToPostmortem.length
+    : 0;
+
+  const timesToCloseActions = closedActions.map(
+    (action) => action.closedAt!.getTime() - action.createdAt.getTime()
+  );
+  const avgTimeToCloseActions = timesToCloseActions.length
+    ? timesToCloseActions.reduce((a, b) => a + b, 0) / timesToCloseActions.length
+    : 0;
+
+  const teams = Array.from(new Set(incidents.map((i) => i.team)));
+  const teamMetrics: Record<string, {
+    percentPostmortemsCompleted: number;
+    percentActionsClosed: number;
+    avgTimeToPostmortemHours: number;
+    avgTimeToCloseActionsHours: number;
+  }> = {};
+
+  teams.forEach((team) => {
+    const teamIncidents = incidents.filter((i) => i.team === team);
+    const teamActions = actions.filter((a) =>
+      teamIncidents.some((incident) => incident.id === a.incidentId)
+    );
+    const teamIncidentsWithPostmortems = teamIncidents.filter((incident) =>
+      postmortems.some((pm) => pm.incidentId === incident.id)
+    );
+    const teamClosedActions = teamActions.filter((a) => a.status === 'closed');
+    const teamTimesToPostmortem = teamIncidentsWithPostmortems.map((incident) => {
+      const pm = postmortems.find((p) => p.incidentId === incident.id)!;
+      return pm.completedAt.getTime() - incident.createdAt.getTime();
+    });
+    const teamTimesToCloseActions = teamClosedActions.map(
+      (a) => a.closedAt!.getTime() - a.createdAt.getTime()
+    );
+
+    teamMetrics[team] = {
+      percentPostmortemsCompleted: teamIncidents.length
+        ? (teamIncidentsWithPostmortems.length / teamIncidents.length) * 100
+        : 0,
+      percentActionsClosed: teamActions.length
+        ? (teamClosedActions.length / teamActions.length) * 100
+        : 0,
+      avgTimeToPostmortemHours: teamTimesToPostmortem.length
+        ? msToHours(
+            teamTimesToPostmortem.reduce((a, b) => a + b, 0) /
+              teamTimesToPostmortem.length
+          )
+        : 0,
+      avgTimeToCloseActionsHours: teamTimesToCloseActions.length
+        ? msToHours(
+            teamTimesToCloseActions.reduce((a, b) => a + b, 0) /
+              teamTimesToCloseActions.length
+          )
+        : 0
+    };
+  });
+
   res.json({
     metrics: {
-      uptime: 99.9,
-      incidentsLastWeek: 5
+      percentPostmortemsCompleted,
+      percentActionsClosed,
+      avgTimeToPostmortemHours: msToHours(avgTimeToPostmortem),
+      avgTimeToCloseActionsHours: msToHours(avgTimeToCloseActions),
+      teamMetrics
     }
   });
 });

--- a/backend/src/routes/postmortems.ts
+++ b/backend/src/routes/postmortems.ts
@@ -1,13 +1,11 @@
 import { Router } from 'express';
+import { postmortems } from '../storage';
 
 const router = Router();
 
 router.get('/', (_req, res) => {
   res.json({
-    postmortems: [
-      { id: 1, incidentId: 1, summary: 'Resolved database outage' },
-      { id: 2, incidentId: 2, summary: 'Fixed network configuration' }
-    ]
+    postmortems
   });
 });
 

--- a/backend/src/storage.ts
+++ b/backend/src/storage.ts
@@ -1,0 +1,75 @@
+export interface Incident {
+  id: number;
+  title: string;
+  team: string;
+  status: 'open' | 'closed';
+  createdAt: Date;
+}
+
+export interface Postmortem {
+  id: number;
+  incidentId: number;
+  summary: string;
+  completedAt: Date;
+}
+
+export interface Action {
+  id: number;
+  incidentId: number;
+  description: string;
+  status: 'open' | 'closed';
+  createdAt: Date;
+  closedAt?: Date;
+}
+
+export const incidents: Incident[] = [
+  {
+    id: 1,
+    title: 'Database outage',
+    team: 'Database',
+    status: 'closed',
+    createdAt: new Date('2024-05-01T10:00:00Z')
+  },
+  {
+    id: 2,
+    title: 'Network issue',
+    team: 'Networking',
+    status: 'open',
+    createdAt: new Date('2024-05-03T12:00:00Z')
+  }
+];
+
+export const postmortems: Postmortem[] = [
+  {
+    id: 1,
+    incidentId: 1,
+    summary: 'Resolved database outage',
+    completedAt: new Date('2024-05-02T10:00:00Z')
+  }
+];
+
+export const actions: Action[] = [
+  {
+    id: 1,
+    incidentId: 1,
+    description: 'Restart database service',
+    status: 'closed',
+    createdAt: new Date('2024-05-01T11:00:00Z'),
+    closedAt: new Date('2024-05-01T12:00:00Z')
+  },
+  {
+    id: 2,
+    incidentId: 1,
+    description: 'Update firewall rules',
+    status: 'open',
+    createdAt: new Date('2024-05-01T11:30:00Z')
+  },
+  {
+    id: 3,
+    incidentId: 2,
+    description: 'Investigate network configuration',
+    status: 'closed',
+    createdAt: new Date('2024-05-03T12:30:00Z'),
+    closedAt: new Date('2024-05-03T13:30:00Z')
+  }
+];

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,42 @@
+# Metrics API
+
+The `/metrics` endpoint exposes system and team performance statistics.
+
+```
+GET /metrics
+```
+
+## Response
+
+```json
+{
+  "metrics": {
+    "percentPostmortemsCompleted": 50.0,
+    "percentActionsClosed": 66.67,
+    "avgTimeToPostmortemHours": 24,
+    "avgTimeToCloseActionsHours": 1,
+    "teamMetrics": {
+      "Database": {
+        "percentPostmortemsCompleted": 100,
+        "percentActionsClosed": 50,
+        "avgTimeToPostmortemHours": 24,
+        "avgTimeToCloseActionsHours": 1
+      },
+      "Networking": {
+        "percentPostmortemsCompleted": 0,
+        "percentActionsClosed": 100,
+        "avgTimeToPostmortemHours": 0,
+        "avgTimeToCloseActionsHours": 1
+      }
+    }
+  }
+}
+```
+
+### Fields
+
+- `percentPostmortemsCompleted` – percentage of incidents that have a completed postmortem.
+- `percentActionsClosed` – percentage of actions that are closed.
+- `avgTimeToPostmortemHours` – average hours from incident creation to postmortem completion.
+- `avgTimeToCloseActionsHours` – average hours from action creation to closure.
+- `teamMetrics` – object keyed by team name containing the above metrics for each team.


### PR DESCRIPTION
## Summary
- track incident postmortems and action status in shared storage
- compute completion percentages and average resolution times in `/metrics`
- document metrics API and team-level breakdown

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af683462cc83299e10d72b975f3b34