### PR TITLE
Add role-based access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Set the connector credentials and API URLs in your `.env` file:
 
 The `JWT_SECRET` key is also required for authentication.
 
+## Roles
+
+JWT tokens include a `role` claim used for role-based access control.
+The sample backend defines `admin` and `user` roles. Endpoints like
+`/actions` and `/metrics` are limited to users with the `admin` role.
+
 ## Documentation
 
 - [Integration connectors](docs/integrations.md)

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import actions from './routes/actions';
 import metrics from './routes/metrics';
 import authRoutes from './routes/auth';
 import authMiddleware from './middleware/auth';
+import rbac from './middleware/rbac';
 import errorHandler from './middleware/errorHandler';
 import logger from './middleware/logger';
 
@@ -23,8 +24,8 @@ app.use(logger);
 app.use('/auth', authRoutes);
 app.use('/incidents', authMiddleware, incidents);
 app.use('/postmortems', authMiddleware, postmortems);
-app.use('/actions', authMiddleware, actions);
-app.use('/metrics', authMiddleware, metrics);
+app.use('/actions', authMiddleware, rbac(['admin']), actions);
+app.use('/metrics', authMiddleware, rbac(['admin']), metrics);
 
 app.use(errorHandler);
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,11 +1,21 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
-export interface AuthRequest extends Request {
-  user?: string | jwt.JwtPayload;
+export interface UserPayload {
+  id: number;
+  username: string;
+  role: string;
 }
 
-export default function auth(req: AuthRequest, res: Response, next: NextFunction) {
+export interface AuthRequest extends Request {
+  user?: UserPayload;
+}
+
+export default function auth(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+) {
   const authHeader = req.headers['authorization'];
   if (!authHeader) {
     return res.status(401).json({ message: 'No token provided' });
@@ -14,7 +24,7 @@ export default function auth(req: AuthRequest, res: Response, next: NextFunction
   const [, token] = authHeader.split(' ');
 
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET!);
+    const decoded = jwt.verify(token, process.env.JWT_SECRET!) as UserPayload;
     req.user = decoded;
     next();
   } catch (err) {

--- a/backend/src/middleware/rbac.ts
+++ b/backend/src/middleware/rbac.ts
@@ -1,0 +1,12 @@
+import { Response, NextFunction } from 'express';
+import { AuthRequest } from './auth';
+
+export default function rbac(roles: string[]) {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const user = req.user;
+    if (!user || !roles.includes(user.role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -6,12 +6,19 @@ import validate from '../middleware/validate';
 
 const router = Router();
 
-// Example in-memory user. In a real app, replace with DB lookup.
+// Example in-memory users. In a real app, replace with DB lookup.
 const users = [
   {
     id: 1,
     username: 'admin',
-    passwordHash: bcrypt.hashSync('password', 10)
+    passwordHash: bcrypt.hashSync('password', 10),
+    role: 'admin'
+  },
+  {
+    id: 2,
+    username: 'user',
+    passwordHash: bcrypt.hashSync('password', 10),
+    role: 'user'
   }
 ];
 
@@ -33,9 +40,13 @@ router.post('/login', validate(loginSchema), async (req, res) => {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
 
-  const token = jwt.sign({ id: user.id, username: user.username }, process.env.JWT_SECRET!, {
-    expiresIn: '1h'
-  });
+  const token = jwt.sign(
+    { id: user.id, username: user.username, role: user.role },
+    process.env.JWT_SECRET!,
+    {
+      expiresIn: '1h'
+    }
+  );
 
   res.json({ token });
 });

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,6 +1,7 @@
 # Metrics API
 
 The `/metrics` endpoint exposes system and team performance statistics.
+It is restricted to users with the `admin` role.
 
 ```
 GET /metrics


### PR DESCRIPTION
## Summary
- include role claim in JWT payloads and user model
- add role-based authorization middleware and secure actions/metrics routes
- document available roles and admin-only metrics access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af692e52608329847515528c83a000