### PR TITLE
Handle timeline errors with UI alerts

### DIFF
--- a/frontend/src/api/timeline.ts
+++ b/frontend/src/api/timeline.ts
@@ -16,7 +16,19 @@ export async function fetchTimelineEvents(
 
   const res = await fetch(`/timeline?${params.toString()}`);
   if (!res.ok) {
-    throw new Error('Failed to fetch timeline events');
+    let message = 'Failed to fetch timeline events';
+    try {
+      const err = await res.json();
+      message = err.error || err.message || message;
+    } catch {
+      try {
+        const text = await res.text();
+        if (text) message = text;
+      } catch {
+        /* ignore */
+      }
+    }
+    throw new Error(message);
   }
   const data = await res.json();
   return data.events as TimelineEvent[];

--- a/frontend/src/components/PostmortemDetail.tsx
+++ b/frontend/src/components/PostmortemDetail.tsx
@@ -23,6 +23,7 @@ export default function PostmortemDetail({ postmortem }: Props) {
   const [suggestions, setSuggestions] = useState<
     Partial<Record<keyof Narrative, string>>
   >({});
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -30,9 +31,9 @@ export default function PostmortemDetail({ postmortem }: Props) {
         const events: TimelineEvent[] = await fetchTimelineEvents();
         const gen = await generatePostmortemNarrative(events);
         setNarrative(gen);
+        setError(null);
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err);
+        setError(err instanceof Error ? err.message : String(err));
       }
     }
     load();
@@ -47,9 +48,9 @@ export default function PostmortemDetail({ postmortem }: Props) {
     try {
       const text = await rewriteBlameless(narrative[field]);
       setSuggestions((prev) => ({ ...prev, [field]: text }));
+      setError(null);
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(err);
+      setError(err instanceof Error ? err.message : String(err));
     }
   };
 
@@ -74,6 +75,14 @@ export default function PostmortemDetail({ postmortem }: Props) {
 
   return (
     <div className="space-y-4">
+      {error && (
+        <div
+          role="alert"
+          className="p-2 bg-red-100 text-red-600 rounded"
+        >
+          {error}
+        </div>
+      )}
       <div
         id="postmortem-content"
         className="p-4 border border-neutral-200 dark:border-neutral-700 rounded bg-white dark:bg-neutral-800"

--- a/frontend/src/components/TimelineTab.tsx
+++ b/frontend/src/components/TimelineTab.tsx
@@ -6,6 +6,7 @@ export default function TimelineTab() {
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
   const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     async function load() {
@@ -16,9 +17,9 @@ export default function TimelineTab() {
         setEvents(data);
         const providers = Array.from(new Set(data.map((ev) => ev.source)));
         setSelectedProviders(providers);
+        setError(null);
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error(err);
+        setError(err instanceof Error ? err.message : String(err));
       }
     }
     load();
@@ -55,6 +56,11 @@ export default function TimelineTab() {
 
   return (
     <div className="space-y-4">
+      {error && (
+        <div role="alert" className="p-2 bg-red-100 text-red-600 rounded">
+          {error}
+        </div>
+      )}
       <div className="flex flex-wrap gap-4 items-end">
         <div>
           <label className="block text-sm">Start</label>

--- a/frontend/src/components/__tests__/PostmortemDetail.test.tsx
+++ b/frontend/src/components/__tests__/PostmortemDetail.test.tsx
@@ -1,0 +1,27 @@
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import PostmortemDetail from '../PostmortemDetail';
+import { fetchTimelineEvents } from '../../api/timeline';
+import { generatePostmortemNarrative } from '../../ai/narrative';
+
+jest.mock('../../api/timeline');
+jest.mock('../../ai/narrative');
+
+describe('PostmortemDetail', () => {
+  it('renders error when timeline fetch fails', async () => {
+    (fetchTimelineEvents as jest.Mock).mockRejectedValue(new Error('timeline failed'));
+    (generatePostmortemNarrative as jest.Mock).mockResolvedValue(null);
+
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <PostmortemDetail
+          postmortem={{ title: 't', incidentId: '1', summary: 's' }}
+        />
+      );
+    });
+    expect(container.textContent).toContain('timeline failed');
+    root.unmount();
+  });
+});

--- a/frontend/src/components/__tests__/TimelineTab.test.tsx
+++ b/frontend/src/components/__tests__/TimelineTab.test.tsx
@@ -1,0 +1,19 @@
+import { act } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+import TimelineTab from '../TimelineTab';
+import { fetchTimelineEvents } from '../../api/timeline';
+
+jest.mock('../../api/timeline');
+
+describe('TimelineTab', () => {
+  it('renders error when fetch fails', async () => {
+    (fetchTimelineEvents as jest.Mock).mockRejectedValue(new Error('failed to load'));
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    await act(async () => {
+      root.render(<TimelineTab />);
+    });
+    expect(container.textContent).toContain('failed to load');
+    root.unmount();
+  });
+});


### PR DESCRIPTION
## Summary
- Surface timeline fetching and rewrite errors directly in PostmortemDetail with user-facing alerts.
- Show timeline load errors in TimelineTab and improve fetchTimelineEvents error messages.
- Add unit tests ensuring error messages render.

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6b71930c832994f62c8f0dc544e3