### PR TITLE
test: add backend and frontend CI

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,11 +1,12 @@
-name: Frontend Tests
+name: Frontend and Backend Tests
 
 on:
   push:
   pull_request:
 
 jobs:
-  test:
+  frontend:
+    name: Frontend Tests
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -15,5 +16,23 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm install
+      - run: npm test
+
+  backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
       - run: npm install
       - run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,14 @@ cd integrations && npm test
 ```
 
 Pull requests should only be merged when the relevant tests pass.
+
+## Continuous Integration
+
+GitHub Actions runs frontend and backend test jobs on every push and pull request. These jobs install Node 18 dependencies, cache them for faster builds, and fail the pipeline if `npm test` exits with a non-zero status.
+
+Run the same checks locally before committing:
+
+```bash
+cd backend && npm test
+cd frontend && npm test
+```


### PR DESCRIPTION
## Summary
- run backend and frontend test suites in the workflow
- cache Node dependencies for faster builds
- document CI in contributing guide

## Testing
- `cd backend && npm test` (fails: Missing script "test")
- `cd frontend && npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)
- `cd frontend && npm test` (fails: sh: 1: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68afe5f2ab2c8329af341d46a510b61c