### PR TITLE
chore: centralize incident types

### DIFF
--- a/frontend/src/components/ActionsTab.tsx
+++ b/frontend/src/components/ActionsTab.tsx
@@ -1,20 +1,24 @@
 import { PieChart, Pie, Tooltip, ResponsiveContainer } from 'recharts';
 import { actions } from '../utils/mock/actions';
+import type { Action } from '../types';
 
 interface StatusCount {
   status: string;
   value: number;
 }
 
-const data: StatusCount[] = actions.reduce<StatusCount[]>((acc, action) => {
-  const found = acc.find((item) => item.status === action.status);
-  if (found) {
-    found.value += 1;
-  } else {
-    acc.push({ status: action.status, value: 1 });
-  }
-  return acc;
-}, []);
+const data: StatusCount[] = actions.reduce<StatusCount[]>(
+  (acc, action: Action) => {
+    const found = acc.find((item) => item.status === action.status);
+    if (found) {
+      found.value += 1;
+    } else {
+      acc.push({ status: action.status, value: 1 });
+    }
+    return acc;
+  },
+  []
+);
 
 export default function ActionsTab() {
   return (

--- a/frontend/src/components/IncidentsTab.tsx
+++ b/frontend/src/components/IncidentsTab.tsx
@@ -1,20 +1,24 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import { incidents } from '../utils/mock/incidents';
+import type { Incident } from '../types';
 
 interface SeverityCount {
   severity: string;
   count: number;
 }
 
-const data: SeverityCount[] = incidents.reduce<SeverityCount[]>((acc, incident) => {
-  const found = acc.find((item) => item.severity === incident.severity);
-  if (found) {
-    found.count += 1;
-  } else {
-    acc.push({ severity: incident.severity, count: 1 });
-  }
-  return acc;
-}, []);
+const data: SeverityCount[] = incidents.reduce<SeverityCount[]>(
+  (acc, incident: Incident) => {
+    const found = acc.find((item) => item.severity === incident.severity);
+    if (found) {
+      found.count += 1;
+    } else {
+      acc.push({ severity: incident.severity, count: 1 });
+    }
+    return acc;
+  },
+  []
+);
 
 export default function IncidentsTab() {
   return (

--- a/frontend/src/components/__tests__/PostmortemDetail.test.tsx
+++ b/frontend/src/components/__tests__/PostmortemDetail.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import PostmortemDetail from '../PostmortemDetail';
 import { fetchTimelineEvents } from '../../services/timeline';
 import { generatePostmortemNarrative } from '../../services/ai/narrative';
+import type { Postmortem } from '../../types';
 
 jest.mock('../../services/timeline');
 jest.mock('../../services/ai/narrative');
@@ -11,11 +12,14 @@ describe('PostmortemDetail', () => {
     (fetchTimelineEvents as jest.Mock).mockRejectedValue(new Error('timeline failed'));
     (generatePostmortemNarrative as jest.Mock).mockResolvedValue(null);
 
-    render(
-      <PostmortemDetail
-        postmortem={{ id: 1, title: 't', incidentId: '1', summary: 's', tags: [] }}
-      />
-    );
+    const pm: Postmortem = {
+      id: 1,
+      title: 't',
+      incidentId: '1',
+      summary: 's',
+      tags: [],
+    };
+    render(<PostmortemDetail postmortem={pm} />);
 
     expect(await screen.findByRole('alert')).toHaveTextContent('timeline failed');
   });
@@ -29,11 +33,14 @@ describe('PostmortemDetail', () => {
       resolution: 'res',
     });
 
-    render(
-      <PostmortemDetail
-        postmortem={{ id: 1, title: 't', incidentId: '1', summary: 's', tags: [] }}
-      />
-    );
+    const pm: Postmortem = {
+      id: 1,
+      title: 't',
+      incidentId: '1',
+      summary: 's',
+      tags: [],
+    };
+    render(<PostmortemDetail postmortem={pm} />);
 
     expect(await screen.findByDisplayValue('det')).toBeInTheDocument();
   });

--- a/frontend/src/components/__tests__/PostmortemSearch.test.tsx
+++ b/frontend/src/components/__tests__/PostmortemSearch.test.tsx
@@ -1,23 +1,38 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import PostmortemSearch from '../PostmortemSearch';
 import { searchPostmortems } from '../../services/postmortems';
+import type { Postmortem } from '../../types';
 
 jest.mock('../../services/postmortems');
 
 describe('PostmortemSearch', () => {
   it('renders results from search', async () => {
-    (searchPostmortems as jest.Mock).mockResolvedValue([
-      { id: 1, incidentId: 'INC-001', title: 'Database outage', summary: '', tags: ['database'] },
-    ]);
+    const mockResults: Postmortem[] = [
+      {
+        id: 1,
+        incidentId: 'INC-001',
+        title: 'Database outage',
+        summary: '',
+        tags: ['database'],
+      },
+    ];
+    (searchPostmortems as jest.Mock).mockResolvedValue(mockResults);
     const onSelect = jest.fn();
     render(<PostmortemSearch onSelect={onSelect} />);
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
   });
 
   it('calls onSelect when a result is clicked', async () => {
-    (searchPostmortems as jest.Mock).mockResolvedValue([
-      { id: 1, incidentId: 'INC-001', title: 'Database outage', summary: '', tags: ['database'] },
-    ]);
+    const mockResults: Postmortem[] = [
+      {
+        id: 1,
+        incidentId: 'INC-001',
+        title: 'Database outage',
+        summary: '',
+        tags: ['database'],
+      },
+    ];
+    (searchPostmortems as jest.Mock).mockResolvedValue(mockResults);
     const onSelect = jest.fn();
     render(<PostmortemSearch onSelect={onSelect} />);
     const item = await screen.findByText('Database outage');

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -4,6 +4,7 @@ import Dashboard from '../Dashboard';
 import { fetchTimelineEvents } from '../../services/timeline';
 import { generatePostmortemNarrative } from '../../services/ai/narrative';
 import { searchPostmortems } from '../../services/postmortems';
+import type { Postmortem } from '../../types';
 
 jest.mock('../../components/IncidentsTab', () => () => <div>IncidentsTab</div>);
 jest.mock('../../components/ActionsTab', () => () => <div>ActionsTab</div>);
@@ -26,9 +27,16 @@ describe('Dashboard', () => {
       mitigation: '',
       resolution: '',
     });
-    (searchPostmortems as jest.Mock).mockResolvedValue([
-      { id: 1, title: 'Database outage', incidentId: 'INC-001', summary: '', tags: ['database'] },
-    ]);
+    const mockResults: Postmortem[] = [
+      {
+        id: 1,
+        title: 'Database outage',
+        incidentId: 'INC-001',
+        summary: '',
+        tags: ['database'],
+      },
+    ];
+    (searchPostmortems as jest.Mock).mockResolvedValue(mockResults);
 
     const user = userEvent.setup();
     render(<Dashboard />);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,6 +11,16 @@ export interface IncidentResponse {
   timestamp: string;
 }
 
+export interface Incident {
+  id: number;
+  severity: 'Critical' | 'High' | 'Medium' | 'Low';
+}
+
+export interface Action {
+  id: number;
+  status: 'Open' | 'In Progress' | 'Completed';
+}
+
 export interface Postmortem {
   id: number;
   incidentId: string;

--- a/frontend/src/utils/mock/actions.ts
+++ b/frontend/src/utils/mock/actions.ts
@@ -1,7 +1,4 @@
-export interface Action {
-  id: number;
-  status: 'Open' | 'In Progress' | 'Completed';
-}
+import type { Action } from '../../types';
 
 export const actions: Action[] = [
   { id: 1, status: 'Open' },

--- a/frontend/src/utils/mock/incidents.ts
+++ b/frontend/src/utils/mock/incidents.ts
@@ -1,7 +1,4 @@
-export interface Incident {
-  id: number;
-  severity: 'Critical' | 'High' | 'Medium' | 'Low';
-}
+import type { Incident } from '../../types';
 
 export const incidents: Incident[] = [
   { id: 1, severity: 'Critical' },


### PR DESCRIPTION
## Summary
- add shared types for Incident and Action
- update mocks, components, and tests to reuse shared types

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00bb3075483299483742c6f89d576