### PR TITLE
Refactor Dashboard with sidebar navigation

### DIFF
--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,19 +5,11 @@ import MetricsTab from '../components/MetricsTab';
 import PostmortemDetail from '../components/PostmortemDetail';
 import PostmortemSearch from '../components/PostmortemSearch';
 import type { Postmortem } from '../types';
-import TimelineTab from '../components/TimelineTab';
-import CollaborationTab from '../components/CollaborationTab';
-import ReviewAgenda from '../components/ReviewAgenda';
-import RemediationActions from '../components/RemediationActions';
-
 const tabs = [
   'Incidents',
   'Postmortems',
   'Actions',
   'Metrics',
-  'Timeline',
-  'Collaboration',
-  'Review',
 ] as const;
 type Tab = typeof tabs[number];
 
@@ -27,23 +19,23 @@ export default function Dashboard() {
     useState<Postmortem | null>(null);
 
   return (
-    <div className="p-4">
-      <nav className="border-b border-neutral-200 dark:border-neutral-700 mb-4 flex space-x-4 overflow-x-auto">
+    <div className="flex h-screen">
+      <aside className="flex flex-col w-56 border-r bg-neutral-50 dark:bg-neutral-900">
         {tabs.map((tab) => (
           <button
             key={tab}
-            className={`pb-2 -mb-px transition-colors ${
+            className={`px-4 py-2 text-left transition-colors ${
               active === tab
-                ? 'border-b-2 border-accent text-accent font-medium'
-                : 'text-neutral-600 hover:text-neutral-800 dark:text-neutral-400 dark:hover:text-neutral-200'
+                ? 'bg-accent/20 text-accent font-medium'
+                : 'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800'
             }`}
             onClick={() => setActive(tab)}
           >
             {tab}
           </button>
         ))}
-      </nav>
-      <div>
+      </aside>
+      <main className="flex-1 overflow-y-auto p-4">
         {active === 'Incidents' && <IncidentsTab />}
         {active === 'Postmortems' && (
           <div className="space-y-4">
@@ -55,15 +47,7 @@ export default function Dashboard() {
         )}
         {active === 'Actions' && <ActionsTab />}
         {active === 'Metrics' && <MetricsTab />}
-        {active === 'Timeline' && <TimelineTab />}
-        {active === 'Collaboration' && <CollaborationTab />}
-        {active === 'Review' && (
-          <div className="space-y-4">
-            <ReviewAgenda />
-            <RemediationActions />
-          </div>
-        )}
-      </div>
+      </main>
     </div>
   );
 }

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -9,10 +9,6 @@ import type { Postmortem } from '../../types';
 jest.mock('../../components/IncidentsTab', () => () => <div>IncidentsTab</div>);
 jest.mock('../../components/ActionsTab', () => () => <div>ActionsTab</div>);
 jest.mock('../../components/MetricsTab', () => () => <div>MetricsTab</div>);
-jest.mock('../../components/TimelineTab', () => () => <div>TimelineTab</div>);
-jest.mock('../../components/CollaborationTab', () => () => <div>CollaborationTab</div>);
-jest.mock('../../components/ReviewAgenda', () => () => <div>ReviewAgenda</div>);
-jest.mock('../../components/RemediationActions', () => () => <div>RemediationActions</div>);
 
 jest.mock('../../services/timeline');
 jest.mock('../../services/ai/narrative');
@@ -41,7 +37,7 @@ describe('Dashboard', () => {
     const user = userEvent.setup();
     render(<Dashboard />);
 
-    await user.click(screen.getByText('Postmortems'));
+    await user.click(screen.getByRole('button', { name: 'Postmortems' }));
     const row = await screen.findByText('Database outage');
     await user.click(row);
 


### PR DESCRIPTION
## Summary
- replace Dashboard top tabs with left sidebar and simplify tab list
- update Dashboard test to use sidebar buttons

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0199e291083299b1d6e89b4bb4c79