### PR TITLE
feat: improve dashboard responsiveness

### DIFF
--- a/frontend/src/components/ActionsTab.tsx
+++ b/frontend/src/components/ActionsTab.tsx
@@ -22,7 +22,7 @@ const data: StatusCount[] = actions.reduce<StatusCount[]>(
 
 export default function ActionsTab() {
   return (
-    <div className="w-full h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
+    <div className="w-full min-w-0 h-48 md:h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
       <ResponsiveContainer>
         <PieChart>
           <Pie data={data} dataKey="value" nameKey="status" fill="#82ca9d" label />

--- a/frontend/src/components/IncidentsTab.tsx
+++ b/frontend/src/components/IncidentsTab.tsx
@@ -22,7 +22,7 @@ const data: SeverityCount[] = incidents.reduce<SeverityCount[]>(
 
 export default function IncidentsTab() {
   return (
-    <div className="w-full h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
+    <div className="w-full min-w-0 h-48 md:h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
       <ResponsiveContainer>
         <BarChart data={data}>
           <XAxis dataKey="severity" />

--- a/frontend/src/components/MetricsTab.tsx
+++ b/frontend/src/components/MetricsTab.tsx
@@ -3,7 +3,7 @@ import { mttrData } from '../utils/mock/metrics';
 
 export default function MetricsTab() {
   return (
-    <div className="w-full h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
+    <div className="w-full min-w-0 h-48 md:h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
       <ResponsiveContainer>
         <LineChart data={mttrData}>
           <XAxis dataKey="date" />

--- a/frontend/src/components/PostmortemTable.tsx
+++ b/frontend/src/components/PostmortemTable.tsx
@@ -120,7 +120,7 @@ export default function PostmortemTable({ onSelect }: Props) {
       <div className="overflow-x-auto">
         <table
           {...getTableProps()}
-          className="min-w-full border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 rounded"
+          className="min-w-full border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 rounded text-xs sm:text-sm"
         >
         <thead>
           {headerGroups.map((headerGroup: any) => (

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -36,17 +36,29 @@ export default function Dashboard() {
         ))}
       </aside>
       <main className="flex-1 overflow-y-auto p-4">
-        {active === 'Incidents' && <IncidentsTab />}
+        {active === 'Incidents' && (
+          <div className="max-w-screen-xl mx-auto grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <IncidentsTab />
+          </div>
+        )}
         {active === 'Postmortems' && (
-          <div className="space-y-4">
+          <div className="max-w-screen-xl mx-auto space-y-4">
             <PostmortemSearch onSelect={(pm) => setSelectedPostmortem(pm)} />
             {selectedPostmortem && (
               <PostmortemDetail postmortem={selectedPostmortem} />
             )}
           </div>
         )}
-        {active === 'Actions' && <ActionsTab />}
-        {active === 'Metrics' && <MetricsTab />}
+        {active === 'Actions' && (
+          <div className="max-w-screen-xl mx-auto grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <ActionsTab />
+          </div>
+        )}
+        {active === 'Metrics' && (
+          <div className="max-w-screen-xl mx-auto grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+            <MetricsTab />
+          </div>
+        )}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- wrap dashboard tabs with responsive grid layouts and max-width constraint
- allow charts to shrink on small screens and adapt heights
- tighten table typography for better readability on mobile

## Testing
- `npm test` *(fails: jest-environment-jsdom cannot be found)*
- `npm run build` *(fails: tsc headers type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d07db008329b5c96bf22f338bc2