### PR TITLE
feat: add theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,11 +8,7 @@
   </head>
   <body class="bg-neutral-50 text-neutral-900 dark:bg-neutral-900 dark:text-neutral-100 font-sans">
     <div id="root"></div>
+    <script type="module" src="/src/theme-init.ts"></script>
     <script type="module" src="/src/main.tsx"></script>
-    <script>
-      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.classList.add('dark');
-      }
-    </script>
   </body>
 </html>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,10 @@
+import { useTheme } from '../hooks/useTheme';
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  return (
+    <button onClick={toggleTheme} aria-label="Toggle theme">
+      {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
+    </button>
+  );
+}

--- a/frontend/src/components/__tests__/ThemeToggle.test.tsx
+++ b/frontend/src/components/__tests__/ThemeToggle.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ThemeToggle from '../ThemeToggle';
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
+  });
+
+  it('saves and applies the preferred theme', () => {
+    localStorage.setItem('theme', 'light');
+    render(<ThemeToggle />);
+    const button = screen.getByRole('button', { name: /toggle theme/i });
+
+    fireEvent.click(button);
+    expect(localStorage.getItem('theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+
+    fireEvent.click(button);
+    expect(localStorage.getItem('theme')).toBe('light');
+    expect(document.documentElement.classList.contains('dark')).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  const stored = localStorage.getItem('theme');
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+  const prefersDark =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
+  return prefersDark ? 'dark' : 'light';
+}
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    const root = document.documentElement.classList;
+    if (theme === 'dark') {
+      root.add('dark');
+    } else {
+      root.remove('dark');
+    }
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+  };
+
+  return { theme, toggleTheme };
+}
+
+export default useTheme;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import ActionsTab from '../components/ActionsTab';
 import MetricsTab from '../components/MetricsTab';
 import PostmortemDetail from '../components/PostmortemDetail';
 import PostmortemSearch from '../components/PostmortemSearch';
+import ThemeToggle from '../components/ThemeToggle';
 import type { Postmortem } from '../types';
 const tabs = [
   'Incidents',
@@ -21,6 +22,9 @@ export default function Dashboard() {
   return (
     <div className="flex h-screen">
       <aside className="flex flex-col w-56 border-r bg-neutral-50 dark:bg-neutral-900">
+        <div className="p-4 border-b">
+          <ThemeToggle />
+        </div>
         {tabs.map((tab) => (
           <button
             key={tab}

--- a/frontend/src/theme-init.ts
+++ b/frontend/src/theme-init.ts
@@ -1,0 +1,15 @@
+const stored = localStorage.getItem('theme');
+let theme: 'light' | 'dark';
+if (stored === 'light' || stored === 'dark') {
+  theme = stored;
+} else {
+  const prefersDark =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
+  theme = prefersDark ? 'dark' : 'light';
+}
+if (theme === 'dark') {
+  document.documentElement.classList.add('dark');
+} else {
+  document.documentElement.classList.remove('dark');
+}


### PR DESCRIPTION
## Summary
- add useTheme hook to manage dark/light mode preference
- add ThemeToggle component and integrate into sidebar
- apply stored theme before app mount via module script
- test theme toggle persistence

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01db2c6b48329869ea6481add8b14