### PR TITLE
Add incident table with filtering and search

### DIFF
--- a/frontend/src/components/IncidentTable.tsx
+++ b/frontend/src/components/IncidentTable.tsx
@@ -1,0 +1,156 @@
+import React, { useMemo, useState } from 'react';
+import { useTable, useGlobalFilter, Column } from 'react-table';
+import type { Incident } from '../types';
+import { incidents } from '../utils/mock/incidents';
+
+export default function IncidentTable() {
+  const [severity, setSeverity] = useState('');
+  const [service, setService] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+
+  const severityOptions = useMemo(
+    () => Array.from(new Set(incidents.map((i) => i.severity))),
+    []
+  );
+  const serviceOptions = useMemo(
+    () => Array.from(new Set(incidents.map((i) => i.service))),
+    []
+  );
+
+  const data = useMemo(() => {
+    return incidents.filter((i) => {
+      if (severity && i.severity !== severity) return false;
+      if (service && i.service !== service) return false;
+      if (startDate && new Date(i.date) < new Date(startDate)) return false;
+      if (endDate && new Date(i.date) > new Date(endDate)) return false;
+      return true;
+    });
+  }, [severity, service, startDate, endDate]);
+
+  const columns = useMemo<Column<Incident>[]>(
+    () => [
+      { Header: 'ID', accessor: 'id' },
+      { Header: 'Service', accessor: 'service' },
+      { Header: 'Severity', accessor: 'severity' },
+      { Header: 'Status', accessor: 'status' },
+      { Header: 'Date', accessor: 'date' },
+    ],
+    []
+  );
+
+  const tableInstance = useTable<Incident>({ columns, data }, useGlobalFilter);
+
+  const {
+    getTableProps,
+    getTableBodyProps,
+    headerGroups,
+    rows,
+    prepareRow,
+    state,
+    setGlobalFilter,
+  } = tableInstance;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <input
+          value={state.globalFilter ?? ''}
+          onChange={(e) => setGlobalFilter(e.target.value)}
+          placeholder="Search incidents"
+          aria-label="Search"
+          className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
+        />
+        <select
+          value={severity}
+          onChange={(e) => setSeverity(e.target.value)}
+          aria-label="Severity"
+          className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
+        >
+          <option value="">All Severities</option>
+          {severityOptions.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <select
+          value={service}
+          onChange={(e) => setService(e.target.value)}
+          aria-label="Service"
+          className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
+        >
+          <option value="">All Services</option>
+          {serviceOptions.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <input
+          type="date"
+          value={startDate}
+          onChange={(e) => setStartDate(e.target.value)}
+          aria-label="Start date"
+          className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
+        />
+        <input
+          type="date"
+          value={endDate}
+          onChange={(e) => setEndDate(e.target.value)}
+          aria-label="End date"
+          className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
+        />
+      </div>
+      <div className="overflow-x-auto">
+        <table
+          {...getTableProps()}
+          className="min-w-full border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 rounded text-xs sm:text-sm"
+        >
+          <thead>
+            {headerGroups.map((headerGroup) => (
+              <tr {...headerGroup.getHeaderGroupProps()}>
+                {headerGroup.headers.map((column) => (
+                  <th
+                    {...column.getHeaderProps()}
+                    className="border-b border-neutral-300 dark:border-neutral-700 p-2 text-left bg-neutral-100 dark:bg-neutral-700"
+                  >
+                    {column.render('Header')}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody {...getTableBodyProps()}>
+            {rows.map((row) => {
+              prepareRow(row);
+              return (
+                <tr
+                  {...row.getRowProps()}
+                  className="hover:bg-neutral-100 dark:hover:bg-neutral-700"
+                >
+                  {row.cells.map((cell) => (
+                    <td
+                      {...cell.getCellProps()}
+                      className="p-2 border-b border-neutral-200 dark:border-neutral-700"
+                    >
+                      {cell.render('Cell')}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={columns.length} className="p-2 text-center">
+                  No incidents
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/__tests__/IncidentTable.test.tsx
+++ b/frontend/src/components/__tests__/IncidentTable.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import IncidentTable from '../IncidentTable';
+
+describe('IncidentTable', () => {
+  it('renders all columns', () => {
+    render(<IncidentTable />);
+    ['ID', 'Service', 'Severity', 'Status', 'Date'].forEach((col) => {
+      expect(screen.getByText(col)).toBeInTheDocument();
+    });
+  });
+
+  it('filters by severity', async () => {
+    const user = userEvent.setup();
+    render(<IncidentTable />);
+    await user.selectOptions(screen.getByLabelText('Severity'), 'High');
+    const table = screen.getByRole('table');
+    expect(within(table).getAllByRole('row')).toHaveLength(3);
+    expect(within(table).queryByText('Critical')).toBeNull();
+  });
+
+  it('searches by id', async () => {
+    const user = userEvent.setup();
+    render(<IncidentTable />);
+    const search = screen.getByPlaceholderText('Search incidents');
+    await user.type(search, '6');
+    const table = screen.getByRole('table');
+    expect(within(table).getAllByRole('row')).toHaveLength(2);
+    expect(within(table).getByText('6')).toBeInTheDocument();
+  });
+});
+

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import IncidentsTab from '../components/IncidentsTab';
+import IncidentTable from '../components/IncidentTable';
 import ActionsTab from '../components/ActionsTab';
 import MetricsTab from '../components/MetricsTab';
 import PostmortemDetail from '../components/PostmortemDetail';
@@ -42,7 +42,7 @@ export default function Dashboard() {
       <main className="flex-1 overflow-y-auto p-4">
         {active === 'Incidents' && (
           <div className="max-w-screen-xl mx-auto grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-            <IncidentsTab />
+            <IncidentTable />
           </div>
         )}
         {active === 'Postmortems' && (

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -6,7 +6,7 @@ import { generatePostmortemNarrative } from '../../services/ai/narrative';
 import { searchPostmortems } from '../../services/postmortems';
 import type { Postmortem } from '../../types';
 
-jest.mock('../../components/IncidentsTab', () => () => <div>IncidentsTab</div>);
+jest.mock('../../components/IncidentTable', () => () => <div>IncidentTable</div>);
 jest.mock('../../components/ActionsTab', () => () => <div>ActionsTab</div>);
 jest.mock('../../components/MetricsTab', () => () => <div>MetricsTab</div>);
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -13,7 +13,10 @@ export interface IncidentResponse {
 
 export interface Incident {
   id: number;
+  service: string;
   severity: 'Critical' | 'High' | 'Medium' | 'Low';
+  status: 'Open' | 'In Progress' | 'Resolved';
+  date: string;
 }
 
 export interface Action {

--- a/frontend/src/utils/mock/incidents.ts
+++ b/frontend/src/utils/mock/incidents.ts
@@ -1,11 +1,47 @@
 import type { Incident } from '../../types';
 
 export const incidents: Incident[] = [
-  { id: 1, severity: 'Critical' },
-  { id: 2, severity: 'High' },
-  { id: 3, severity: 'Medium' },
-  { id: 4, severity: 'Low' },
-  { id: 5, severity: 'High' },
-  { id: 6, severity: 'Critical' },
+  {
+    id: 1,
+    service: 'Auth',
+    severity: 'Critical',
+    status: 'Resolved',
+    date: '2024-01-01',
+  },
+  {
+    id: 2,
+    service: 'Payments',
+    severity: 'High',
+    status: 'Open',
+    date: '2024-01-15',
+  },
+  {
+    id: 3,
+    service: 'Search',
+    severity: 'Medium',
+    status: 'In Progress',
+    date: '2024-02-10',
+  },
+  {
+    id: 4,
+    service: 'Auth',
+    severity: 'Low',
+    status: 'Resolved',
+    date: '2024-03-05',
+  },
+  {
+    id: 5,
+    service: 'Orders',
+    severity: 'High',
+    status: 'Open',
+    date: '2024-04-20',
+  },
+  {
+    id: 6,
+    service: 'Payments',
+    severity: 'Critical',
+    status: 'Resolved',
+    date: '2024-05-18',
+  },
 ];
 


### PR DESCRIPTION
## Summary
- extend Incident type with service, status and date
- replace mock incident data with rich objects
- add new IncidentTable component with column filters, date range and search
- render IncidentTable on dashboard
- test IncidentTable column rendering, filtering and search behavior

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01f244f8c832994140d6cb6b5bd8e