### PR TITLE
feat: add read-only postmortem viewer with pdf export

### DIFF
--- a/frontend/src/components/PostmortemViewer.tsx
+++ b/frontend/src/components/PostmortemViewer.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect, useRef, useState } from 'react';
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
+import type { Postmortem } from '../types';
+import { fetchTimelineEvents, TimelineEvent } from '../services/timeline';
+import { loadActions, Remediation } from '../services/remediations';
+
+interface Props {
+  postmortem: Postmortem;
+}
+
+export default function PostmortemViewer({ postmortem }: Props) {
+  const [timeline, setTimeline] = useState<TimelineEvent[]>([]);
+  const [actions, setActions] = useState<Remediation[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const viewerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const events = await fetchTimelineEvents();
+        setTimeline(events);
+        setActions(loadActions());
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    }
+    load();
+  }, []);
+
+  const exportPdf = async () => {
+    if (!viewerRef.current) return;
+    const canvas = await html2canvas(viewerRef.current);
+    const imgData = canvas.toDataURL('image/png');
+    const pdf = new jsPDF('p', 'mm', 'a4');
+    const imgProps = pdf.getImageProperties(imgData);
+    const pdfWidth = pdf.internal.pageSize.getWidth();
+    const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+    pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+    pdf.save(`${postmortem.incidentId}.pdf`);
+  };
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div role="alert" className="p-2 bg-red-100 text-red-600 rounded">
+          {error}
+        </div>
+      )}
+      <div
+        ref={viewerRef}
+        className="p-4 border border-neutral-200 dark:border-neutral-700 rounded bg-white dark:bg-neutral-800 space-y-4"
+      >
+        <h2 className="text-xl font-semibold">{postmortem.title}</h2>
+        <section>
+          <h3 className="font-medium">Summary</h3>
+          <p>{postmortem.summary}</p>
+        </section>
+        <section>
+          <h3 className="font-medium">Impact</h3>
+          <p>{postmortem.impact || ''}</p>
+        </section>
+        <section>
+          <h3 className="font-medium">Root Cause</h3>
+          <p>{postmortem.rootCause || ''}</p>
+        </section>
+        <section>
+          <h3 className="font-medium">Resolution</h3>
+          <p>{postmortem.resolution || ''}</p>
+        </section>
+        <section>
+          <h3 className="font-medium">Timeline</h3>
+          {timeline.length ? (
+            <ul className="list-disc pl-6">
+              {timeline.map((e, idx) => (
+                <li key={idx}>
+                  <span className="font-semibold">{e.timestamp}</span> - {e.description}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p>No timeline events.</p>
+          )}
+        </section>
+        <section>
+          <h3 className="font-medium">Actions</h3>
+          {actions.length ? (
+            <ul className="list-disc pl-6">
+              {actions.map((a) => (
+                <li key={a.id}>{a.description}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>No actions.</p>
+          )}
+        </section>
+        <section>
+          <h3 className="font-medium">Lessons</h3>
+          <p>{postmortem.lessons || ''}</p>
+        </section>
+      </div>
+      <button
+        onClick={exportPdf}
+        className="px-4 py-2 bg-primary text-white rounded hover:bg-primary-dark transition-colors"
+      >
+        Export to PDF
+      </button>
+    </div>
+  );
+}
+

--- a/frontend/src/components/__tests__/PostmortemViewer.test.tsx
+++ b/frontend/src/components/__tests__/PostmortemViewer.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PostmortemViewer from '../PostmortemViewer';
+import { fetchTimelineEvents } from '../../services/timeline';
+import { loadActions } from '../../services/remediations';
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
+import type { Postmortem } from '../../types';
+
+jest.mock('../../services/timeline');
+jest.mock('../../services/remediations');
+
+jest.mock('jspdf', () => {
+  return jest.fn().mockImplementation(() => ({
+    addImage: jest.fn(),
+    getImageProperties: () => ({ width: 100, height: 100 }),
+    internal: { pageSize: { getWidth: () => 100 } },
+    save: jest.fn(),
+  }));
+});
+
+jest.mock('html2canvas');
+
+describe('PostmortemViewer', () => {
+  beforeEach(() => {
+    (fetchTimelineEvents as jest.Mock).mockResolvedValue([
+      { source: 's', timestamp: 't', description: 'event' },
+    ]);
+    (loadActions as jest.Mock).mockReturnValue([
+      { id: '1', provider: 'jira', description: 'action', url: 'u' },
+    ]);
+    (html2canvas as jest.Mock).mockResolvedValue({
+      toDataURL: () => 'data:image/png;base64,',
+      width: 100,
+      height: 100,
+    });
+  });
+
+  it('renders all sections', async () => {
+    const pm: Postmortem = {
+      id: 1,
+      incidentId: '1',
+      title: 'Title',
+      summary: 'Summary',
+      impact: 'Impact',
+      rootCause: 'Root',
+      resolution: 'Resolution',
+      lessons: 'Lessons',
+      tags: [],
+    };
+    render(<PostmortemViewer postmortem={pm} />);
+
+    expect(await screen.findByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('Impact')).toBeInTheDocument();
+    expect(screen.getByText('Root Cause')).toBeInTheDocument();
+    expect(screen.getByText('Resolution')).toBeInTheDocument();
+    expect(screen.getByText('Timeline')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+    expect(screen.getByText('Lessons')).toBeInTheDocument();
+  });
+
+  it('exports to PDF on button click', async () => {
+    const pm: Postmortem = {
+      id: 1,
+      incidentId: '1',
+      title: 'Title',
+      summary: 'Summary',
+      tags: [],
+    };
+    const saveMock = jest.fn();
+    (jsPDF as unknown as jest.Mock).mockImplementation(() => ({
+      addImage: jest.fn(),
+      getImageProperties: () => ({ width: 100, height: 100 }),
+      internal: { pageSize: { getWidth: () => 100 } },
+      save: saveMock,
+    }));
+    render(<PostmortemViewer postmortem={pm} />);
+
+    const btn = await screen.findByText('Export to PDF');
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(html2canvas).toHaveBeenCalled();
+      expect(saveMock).toHaveBeenCalled();
+    });
+  });
+});
+

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import IncidentTable from '../components/IncidentTable';
 import ActionsTab from '../components/ActionsTab';
 import MetricsTab from '../components/MetricsTab';
-import PostmortemDetail from '../components/PostmortemDetail';
+import PostmortemViewer from '../components/PostmortemViewer';
 import PostmortemSearch from '../components/PostmortemSearch';
 import ThemeToggle from '../components/ThemeToggle';
 import type { Postmortem } from '../types';
@@ -49,7 +49,7 @@ export default function Dashboard() {
           <div className="max-w-screen-xl mx-auto space-y-4">
             <PostmortemSearch onSelect={(pm) => setSelectedPostmortem(pm)} />
             {selectedPostmortem && (
-              <PostmortemDetail postmortem={selectedPostmortem} />
+              <PostmortemViewer postmortem={selectedPostmortem} />
             )}
           </div>
         )}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -30,4 +30,8 @@ export interface Postmortem {
   title: string;
   summary: string;
   tags: string[];
+  impact?: string;
+  rootCause?: string;
+  resolution?: string;
+  lessons?: string;
 }


### PR DESCRIPTION
## Summary
- add PostmortemViewer component rendering summary, impact, root cause, resolution, timeline, actions, and lessons with PDF export
- replace PostmortemDetail in Dashboard with PostmortemViewer
- cover section rendering and PDF export with new tests

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02067c1a48329b169a7a83de10b87