### PR TITLE
feat: add incident counts to metrics

### DIFF
--- a/frontend/src/components/MetricsTab.tsx
+++ b/frontend/src/components/MetricsTab.tsx
@@ -1,14 +1,37 @@
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
-import { mttrData } from '../utils/mock/metrics';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  TooltipProps,
+} from 'recharts';
+import { mttrData, type MTTRPoint } from '../utils/mock/metrics';
+
+export function MTTRTooltip({ active, payload }: TooltipProps<number, string>) {
+  if (active && payload && payload.length) {
+    const { mttr, incidentCount } = payload[0].payload as MTTRPoint;
+    return (
+      <div className="bg-white p-2 border border-neutral-200 rounded shadow">
+        MTTR: {mttr}h ({incidentCount} incidents)
+      </div>
+    );
+  }
+  return null;
+}
 
 export default function MetricsTab() {
+  const formatMonth = (value: string) =>
+    new Date(value + '-01').toLocaleString('default', { month: 'short' });
+
   return (
     <div className="w-full min-w-0 h-48 md:h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
       <ResponsiveContainer>
         <LineChart data={mttrData}>
-          <XAxis dataKey="date" />
+          <XAxis dataKey="date" tickFormatter={formatMonth} />
           <YAxis />
-          <Tooltip />
+          <Tooltip content={<MTTRTooltip />} />
           <Line type="monotone" dataKey="mttr" stroke="#8884d8" />
         </LineChart>
       </ResponsiveContainer>

--- a/frontend/src/components/__tests__/MetricsTab.test.tsx
+++ b/frontend/src/components/__tests__/MetricsTab.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { MTTRTooltip } from '../MetricsTab';
+
+describe('MetricsTab tooltip', () => {
+  it('renders MTTR value and incident count', () => {
+    const payload = [{ payload: { mttr: 5, incidentCount: 2, date: '2024-01' } }];
+    render(<MTTRTooltip active payload={payload} />);
+    expect(screen.getByText('MTTR: 5h (2 incidents)')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/mock/metrics.ts
+++ b/frontend/src/utils/mock/metrics.ts
@@ -1,12 +1,13 @@
 export interface MTTRPoint {
   date: string;
   mttr: number; // mean time to recovery in hours
+  incidentCount: number;
 }
 
 export const mttrData: MTTRPoint[] = [
-  { date: '2024-01', mttr: 5 },
-  { date: '2024-02', mttr: 3 },
-  { date: '2024-03', mttr: 4 },
-  { date: '2024-04', mttr: 2 },
+  { date: '2024-01', mttr: 5, incidentCount: 4 },
+  { date: '2024-02', mttr: 3, incidentCount: 2 },
+  { date: '2024-03', mttr: 4, incidentCount: 3 },
+  { date: '2024-04', mttr: 2, incidentCount: 1 },
 ];
 


### PR DESCRIPTION
## Summary
- include incident count in MTTR mock data
- show incident count in metrics chart with custom tooltip
- test tooltip displays MTTR and incident count

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b023beb58c8329aeb3fe6a920c7c7e