### PR TITLE
feat: add react query hooks

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "recharts": "^2.11.0",
     "react-table": "^7.8.0",
     "jspdf": "^2.5.1",
-    "html2canvas": "^1.4.1"
+    "html2canvas": "^1.4.1",
+    "@tanstack/react-query": "^5.36.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/components/IncidentTable.tsx
+++ b/frontend/src/components/IncidentTable.tsx
@@ -1,22 +1,18 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useTable, useGlobalFilter, Column } from 'react-table';
 import type { Incident } from '../types';
-import { fetchIncidents } from '../services/incidents';
+import { useIncidents } from '../services/api';
 
 interface Props {
   severityFilter?: string;
 }
 
 export default function IncidentTable({ severityFilter }: Props) {
-  const [incidents, setIncidents] = useState<Incident[]>([]);
+  const { data: incidents = [] } = useIncidents();
   const [severity, setSeverity] = useState('');
   const [service, setService] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
-
-  useEffect(() => {
-    fetchIncidents().then(setIncidents).catch(() => setIncidents([]));
-  }, []);
 
   const severityOptions = useMemo(
     () => Array.from(new Set(incidents.map((i) => i.severity))),

--- a/frontend/src/components/PostmortemSearch.tsx
+++ b/frontend/src/components/PostmortemSearch.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { searchPostmortems } from '../services/postmortems';
+import { usePostmortems } from '../services/api';
 import type { Postmortem } from '../types';
 
 interface Props {
@@ -8,19 +8,16 @@ interface Props {
 
 export default function PostmortemSearch({ onSelect }: Props) {
   const [query, setQuery] = useState('');
-  const [results, setResults] = useState<Postmortem[]>([]);
+  const { data: results = [], refetch } = usePostmortems(query, {
+    enabled: false,
+  });
 
   useEffect(() => {
-    searchPostmortems('').then(setResults).catch(() => setResults([]));
-  }, []);
+    refetch();
+  }, [refetch]);
 
   const handleSearch = async () => {
-    try {
-      const res = await searchPostmortems(query);
-      setResults(res);
-    } catch {
-      setResults([]);
-    }
+    await refetch();
   };
 
   return (

--- a/frontend/src/components/__tests__/IncidentTable.test.tsx
+++ b/frontend/src/components/__tests__/IncidentTable.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import IncidentTable from '../IncidentTable';
-import { fetchIncidents } from '../../services/incidents';
+import { useIncidents } from '../../services/api';
 import mockIncidents from '../../utils/mock/incidents.json';
 
-jest.mock('../../services/incidents');
+jest.mock('../../services/api', () => ({ useIncidents: jest.fn() }));
 
 describe('IncidentTable', () => {
   beforeEach(() => {
-    (fetchIncidents as jest.Mock).mockResolvedValue(mockIncidents);
+    (useIncidents as jest.Mock).mockReturnValue({ data: mockIncidents });
   });
 
   it('renders all columns', () => {

--- a/frontend/src/components/__tests__/PostmortemSearch.test.tsx
+++ b/frontend/src/components/__tests__/PostmortemSearch.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import PostmortemSearch from '../PostmortemSearch';
-import { searchPostmortems } from '../../services/postmortems';
+import { usePostmortems } from '../../services/api';
 import type { Postmortem } from '../../types';
 
-jest.mock('../../services/postmortems');
+jest.mock('../../services/api', () => ({ usePostmortems: jest.fn() }));
 
 describe('PostmortemSearch', () => {
   it('renders results from search', async () => {
@@ -16,7 +16,10 @@ describe('PostmortemSearch', () => {
         tags: ['database'],
       },
     ];
-    (searchPostmortems as jest.Mock).mockResolvedValue(mockResults);
+    (usePostmortems as jest.Mock).mockReturnValue({
+      data: mockResults,
+      refetch: jest.fn().mockResolvedValue({ data: mockResults }),
+    });
     const onSelect = jest.fn();
     render(<PostmortemSearch onSelect={onSelect} />);
     expect(await screen.findByText('Database outage')).toBeInTheDocument();
@@ -32,7 +35,10 @@ describe('PostmortemSearch', () => {
         tags: ['database'],
       },
     ];
-    (searchPostmortems as jest.Mock).mockResolvedValue(mockResults);
+    (usePostmortems as jest.Mock).mockReturnValue({
+      data: mockResults,
+      refetch: jest.fn().mockResolvedValue({ data: mockResults }),
+    });
     const onSelect = jest.fn();
     render(<PostmortemSearch onSelect={onSelect} />);
     const item = await screen.findByText('Database outage');

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import './index.css';
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>
 );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import type { Incident, Postmortem } from '../types';
+import { fetchIncidents } from './incidents';
+import { searchPostmortems } from './postmortems';
+
+export function useIncidents() {
+  return useQuery<Incident[]>({
+    queryKey: ['incidents'],
+    queryFn: fetchIncidents,
+  });
+}
+
+export function usePostmortems(
+  query: string,
+  options?: { enabled?: boolean }
+) {
+  return useQuery<Postmortem[]>({
+    queryKey: ['postmortems', query],
+    queryFn: () => searchPostmortems(query),
+    ...options,
+  });
+}

--- a/frontend/src/types/react-query.d.ts
+++ b/frontend/src/types/react-query.d.ts
@@ -1,0 +1,22 @@
+declare module '@tanstack/react-query' {
+  import type { ReactNode, FC } from 'react';
+  export class QueryClient {
+    constructor();
+  }
+  export interface QueryClientProviderProps {
+    client: QueryClient;
+    children?: ReactNode;
+  }
+  export const QueryClientProvider: FC<QueryClientProviderProps>;
+
+  export interface UseQueryOptions<TData> {
+    queryKey: readonly unknown[];
+    queryFn: () => Promise<TData> | TData;
+    enabled?: boolean;
+  }
+  export interface UseQueryResult<TData> {
+    data: TData | undefined;
+    refetch: () => Promise<{ data: TData }>;
+  }
+  export function useQuery<TData>(options: UseQueryOptions<TData>): UseQueryResult<TData>;
+}


### PR DESCRIPTION
## Summary
- add @tanstack/react-query and typed hooks for incidents and postmortems
- wrap app with QueryClientProvider
- refactor tables/search to consume query hooks

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02781c8dc8329aebd4be0836d1c54