### PR TITLE
Add reusable loading and error UI components

### DIFF
--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+interface Props {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export default function ErrorMessage({ message = 'Something went wrong', onRetry }: Props) {
+  return (
+    <div className="p-4 text-center">
+      <p className="text-red-600 dark:text-red-400 mb-2">{message}</p>
+      {onRetry && (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="px-3 py-1 bg-primary text-white rounded"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/IncidentTable.tsx
+++ b/frontend/src/components/IncidentTable.tsx
@@ -2,13 +2,20 @@ import React, { useMemo, useState } from 'react';
 import { useTable, useGlobalFilter, Column } from 'react-table';
 import type { Incident } from '../types';
 import { useIncidents } from '../services/api';
+import LoadingSpinner from './LoadingSpinner';
+import ErrorMessage from './ErrorMessage';
 
 interface Props {
   severityFilter?: string;
 }
 
 export default function IncidentTable({ severityFilter }: Props) {
-  const { data: incidents = [] } = useIncidents();
+  const {
+    data: incidents = [],
+    isLoading,
+    isError,
+    refetch,
+  } = useIncidents();
   const [severity, setSeverity] = useState('');
   const [service, setService] = useState('');
   const [startDate, setStartDate] = useState('');
@@ -57,6 +64,19 @@ export default function IncidentTable({ severityFilter }: Props) {
     state,
     setGlobalFilter,
   } = tableInstance;
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (isError) {
+    return (
+      <ErrorMessage
+        message="Failed to load incidents"
+        onRetry={refetch}
+      />
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function LoadingSpinner() {
+  return (
+    <div className="flex justify-center items-center p-4" role="status">
+      <div className="animate-spin rounded-full h-8 w-8 border-2 border-current border-t-transparent"></div>
+      <span className="sr-only">Loading...</span>
+    </div>
+  );
+}

--- a/frontend/src/components/PostmortemSearch.tsx
+++ b/frontend/src/components/PostmortemSearch.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { usePostmortems } from '../services/api';
 import type { Postmortem } from '../types';
+import LoadingSpinner from './LoadingSpinner';
+import ErrorMessage from './ErrorMessage';
 
 interface Props {
   onSelect: (pm: Postmortem) => void;
@@ -8,7 +10,12 @@ interface Props {
 
 export default function PostmortemSearch({ onSelect }: Props) {
   const [query, setQuery] = useState('');
-  const { data: results = [], refetch } = usePostmortems(query, {
+  const {
+    data: results = [],
+    refetch,
+    isLoading,
+    isError,
+  } = usePostmortems(query, {
     enabled: false,
   });
 
@@ -37,18 +44,28 @@ export default function PostmortemSearch({ onSelect }: Props) {
           Search
         </button>
       </div>
-      <ul className="divide-y divide-neutral-200 dark:divide-neutral-700">
-        {results.map((pm) => (
-          <li
-            key={pm.id}
-            className="p-2 cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700"
-            onClick={() => onSelect(pm)}
-          >
-            <div className="font-medium">{pm.title}</div>
-            <div className="text-sm text-neutral-500">{pm.tags.join(', ')}</div>
-          </li>
-        ))}
-      </ul>
+      {isLoading && <LoadingSpinner />}
+      {isError && (
+        <ErrorMessage
+          message="Failed to load postmortems"
+          onRetry={refetch}
+        />
+      )}
+      {!isLoading && !isError && (
+        <ul className="divide-y divide-neutral-200 dark:divide-neutral-700">
+          {results.map((pm) => (
+            <li
+              key={pm.id}
+              className="p-2 cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-700"
+              onClick={() => onSelect(pm)}
+            >
+              <div className="font-medium">{pm.title}</div>
+              <div className="text-sm text-neutral-500">{pm.tags.join(', ')}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/IncidentTable.test.tsx
+++ b/frontend/src/components/__tests__/IncidentTable.test.tsx
@@ -8,7 +8,12 @@ jest.mock('../../services/api', () => ({ useIncidents: jest.fn() }));
 
 describe('IncidentTable', () => {
   beforeEach(() => {
-    (useIncidents as jest.Mock).mockReturnValue({ data: mockIncidents });
+    (useIncidents as jest.Mock).mockReturnValue({
+      data: mockIncidents,
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
   });
 
   it('renders all columns', () => {

--- a/frontend/src/components/__tests__/PostmortemSearch.test.tsx
+++ b/frontend/src/components/__tests__/PostmortemSearch.test.tsx
@@ -18,6 +18,8 @@ describe('PostmortemSearch', () => {
     ];
     (usePostmortems as jest.Mock).mockReturnValue({
       data: mockResults,
+      isLoading: false,
+      isError: false,
       refetch: jest.fn().mockResolvedValue({ data: mockResults }),
     });
     const onSelect = jest.fn();
@@ -37,6 +39,8 @@ describe('PostmortemSearch', () => {
     ];
     (usePostmortems as jest.Mock).mockReturnValue({
       data: mockResults,
+      isLoading: false,
+      isError: false,
       refetch: jest.fn().mockResolvedValue({ data: mockResults }),
     });
     const onSelect = jest.fn();


### PR DESCRIPTION
## Summary
- add reusable `LoadingSpinner` and `ErrorMessage` components
- show loading and error states in `PostmortemSearch` and `IncidentTable`
- adjust tests for updated hooks

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02931acd083299499be9a71b7f0dd