### PR TITLE
feat: add incident summary metrics

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import incidents from './routes/incidents';
 import postmortems from './routes/postmortems';
 import actions from './routes/actions';
 import metrics from './routes/metrics';
+import summary from './routes/summary';
 import authRoutes from './routes/auth';
 import authMiddleware from './middleware/auth';
 import rbac from './middleware/rbac';
@@ -29,6 +30,7 @@ app.use('/incidents', authMiddleware, incidents);
 app.use('/postmortems', authMiddleware, postmortems);
 app.use('/actions', authMiddleware, rbac(['admin']), actions);
 app.use('/metrics', authMiddleware, rbac(['admin']), metrics);
+app.use('/summary', authMiddleware, summary);
 
 const schema = buildSchema(`
   type Postmortem {

--- a/backend/src/routes/summary.ts
+++ b/backend/src/routes/summary.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { incidents } from '../storage';
+
+const router = Router();
+
+const msToHours = (ms: number): number => ms / (1000 * 60 * 60);
+
+router.get('/', (_req, res) => {
+  const now = Date.now();
+  const ninetyDaysAgo = now - 90 * 24 * 60 * 60 * 1000;
+  const recent = incidents.filter((i) => i.createdAt.getTime() >= ninetyDaysAgo);
+
+  const sev1Count = recent.filter((i) => i.severity === 1).length;
+
+  const mttrs = recent
+    .filter((i) => i.resolvedAt)
+    .map((i) => i.resolvedAt!.getTime() - i.createdAt.getTime());
+  const avgMttrHours = mttrs.length
+    ? msToHours(mttrs.reduce((a, b) => a + b, 0) / mttrs.length)
+    : 0;
+
+  const slaMet = recent.filter(
+    (i) =>
+      i.resolvedAt &&
+      i.resolvedAt.getTime() - i.createdAt.getTime() <= i.slaHours * 60 * 60 * 1000
+  ).length;
+  const slaPercent = recent.length ? (slaMet / recent.length) * 100 : 0;
+
+  res.json({ sev1Count, avgMttrHours, slaPercent });
+});
+
+export default router;

--- a/backend/src/storage.ts
+++ b/backend/src/storage.ts
@@ -3,7 +3,10 @@ export interface Incident {
   title: string;
   team: string;
   status: 'open' | 'closed';
+  severity: 1 | 2 | 3 | 4;
   createdAt: Date;
+  resolvedAt?: Date;
+  slaHours: number;
 }
 
 export interface Postmortem {
@@ -29,14 +32,19 @@ export const incidents: Incident[] = [
     title: 'Database outage',
     team: 'Database',
     status: 'closed',
-    createdAt: new Date('2024-05-01T10:00:00Z')
+    severity: 1,
+    createdAt: new Date('2024-05-01T10:00:00Z'),
+    resolvedAt: new Date('2024-05-01T12:00:00Z'),
+    slaHours: 4
   },
   {
     id: 2,
     title: 'Network issue',
     team: 'Networking',
     status: 'open',
-    createdAt: new Date('2024-05-03T12:00:00Z')
+    severity: 2,
+    createdAt: new Date('2024-05-03T12:00:00Z'),
+    slaHours: 8
   }
 ];
 

--- a/frontend/src/components/SummaryBanner.tsx
+++ b/frontend/src/components/SummaryBanner.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { fetchSummary } from '../services/summary';
+import type { Summary } from '../types';
+import LoadingSpinner from './LoadingSpinner';
+import ErrorMessage from './ErrorMessage';
+
+export default function SummaryBanner() {
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = async () => {
+    try {
+      const data = await fetchSummary();
+      setSummary(data);
+      setError(null);
+    } catch (err) {
+      setError('Failed to load summary');
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  if (error) {
+    return <ErrorMessage message={error} onRetry={load} />;
+  }
+
+  if (!summary) {
+    return <LoadingSpinner />;
+  }
+
+  return (
+    <div className="mb-4 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded flex flex-wrap justify-around text-center">
+      <div>
+        <div className="text-sm text-neutral-500">Sev1 Incidents</div>
+        <div className="text-2xl font-semibold" data-testid="sev1-count">{summary.sev1Count}</div>
+      </div>
+      <div>
+        <div className="text-sm text-neutral-500">Avg MTTR (h)</div>
+        <div className="text-2xl font-semibold" data-testid="avg-mttr">{summary.avgMttrHours.toFixed(1)}</div>
+      </div>
+      <div>
+        <div className="text-sm text-neutral-500">SLA %</div>
+        <div className="text-2xl font-semibold" data-testid="sla-percent">{summary.slaPercent.toFixed(0)}%</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/__tests__/SummaryBanner.test.tsx
+++ b/frontend/src/components/__tests__/SummaryBanner.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import SummaryBanner from '../SummaryBanner';
+import { fetchSummary } from '../../services/summary';
+
+jest.mock('../../services/summary');
+
+describe('SummaryBanner', () => {
+  it('renders summary metrics', async () => {
+    (fetchSummary as jest.Mock).mockResolvedValue({
+      sev1Count: 2,
+      avgMttrHours: 5,
+      slaPercent: 80,
+    });
+
+    render(<SummaryBanner />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sev1-count')).toHaveTextContent('2');
+      expect(screen.getByTestId('avg-mttr')).toHaveTextContent('5');
+      expect(screen.getByTestId('sla-percent')).toHaveTextContent('80%');
+    });
+  });
+});

--- a/frontend/src/components/__tests__/summaryService.test.ts
+++ b/frontend/src/components/__tests__/summaryService.test.ts
@@ -1,0 +1,19 @@
+import { fetchSummary } from '../../services/summary';
+
+describe('fetchSummary', () => {
+  it('calls the summary endpoint', async () => {
+    const mockResponse = {
+      sev1Count: 1,
+      avgMttrHours: 2,
+      slaPercent: 90,
+    };
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockResponse,
+    }) as unknown as typeof fetch;
+
+    const data = await fetchSummary();
+    expect(global.fetch).toHaveBeenCalledWith('/summary');
+    expect(data).toEqual(mockResponse);
+  });
+});

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -7,6 +7,7 @@ import MetricsTab from '../components/MetricsTab';
 import PostmortemViewer from '../components/PostmortemViewer';
 import PostmortemSearch from '../components/PostmortemSearch';
 import ThemeToggle from '../components/ThemeToggle';
+import SummaryBanner from '../components/SummaryBanner';
 import type { Postmortem } from '../types';
 const tabs = [
   'Incidents',
@@ -48,6 +49,7 @@ export default function Dashboard() {
         ))}
       </aside>
       <main className="flex-1 overflow-y-auto p-4">
+        <SummaryBanner />
         {active === 'Incidents' && (
           <div className="max-w-screen-xl mx-auto grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             <SeverityBarChart onSelectSeverity={setSeverityFilter} />

--- a/frontend/src/pages/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/__tests__/Dashboard.test.tsx
@@ -10,6 +10,7 @@ jest.mock('../../components/IncidentTable', () => () => <div>IncidentTable</div>
 jest.mock('../../components/SeverityBarChart', () => () => <div>SeverityBarChart</div>);
 jest.mock('../../components/ActionsTab', () => () => <div>ActionsTab</div>);
 jest.mock('../../components/MetricsTab', () => () => <div>MetricsTab</div>);
+jest.mock('../../components/SummaryBanner', () => () => <div>SummaryBanner</div>);
 
 jest.mock('../../services/timeline');
 jest.mock('../../services/ai/narrative');
@@ -37,6 +38,8 @@ describe('Dashboard', () => {
 
     const user = userEvent.setup();
     render(<Dashboard />);
+
+    expect(screen.getByText('SummaryBanner')).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Postmortems' }));
     const row = await screen.findByText('Database outage');

--- a/frontend/src/services/summary.ts
+++ b/frontend/src/services/summary.ts
@@ -1,0 +1,14 @@
+import type { Summary } from '../types';
+import { config } from '../utils/config';
+import mockSummary from '../utils/mock/summary';
+
+export async function fetchSummary(): Promise<Summary> {
+  if (config.useMockData) {
+    return mockSummary;
+  }
+  const res = await fetch('/summary');
+  if (!res.ok) {
+    throw new Error('failed to fetch summary');
+  }
+  return (await res.json()) as Summary;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -35,3 +35,9 @@ export interface Postmortem {
   resolution?: string;
   lessons?: string;
 }
+
+export interface Summary {
+  sev1Count: number;
+  avgMttrHours: number;
+  slaPercent: number;
+}

--- a/frontend/src/utils/mock/summary.ts
+++ b/frontend/src/utils/mock/summary.ts
@@ -1,0 +1,9 @@
+import type { Summary } from '../../types';
+
+const summary: Summary = {
+  sev1Count: 1,
+  avgMttrHours: 2,
+  slaPercent: 50,
+};
+
+export default summary;


### PR DESCRIPTION
## Summary
- extend backend incident model with severity, resolution and SLA info
- add summary API to expose sev1 count, MTTR and SLA percentage
- show summary banner on dashboard with service and tests

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02a4045ec8329b4517c7ccb4f9838