### PR TITLE
feat: add export utilities and buttons

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,8 @@
     "react-table": "^7.8.0",
     "jspdf": "^2.5.1",
     "html2canvas": "^1.4.1",
-    "@tanstack/react-query": "^5.36.1"
+    "@tanstack/react-query": "^5.36.1",
+    "papaparse": "^5.4.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/components/ActionStatusPieChart.tsx
+++ b/frontend/src/components/ActionStatusPieChart.tsx
@@ -1,7 +1,8 @@
 import { PieChart, Pie, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { actions } from '../utils/mock/actions';
 import type { Action } from '../types';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import { exportElementToPDF, exportElementToPNG, exportToCSV } from '../utils/export';
 
 interface Props {
   onSelectStatus: (status: string) => void;
@@ -13,6 +14,7 @@ interface StatusCount {
 }
 
 export default function ActionStatusPieChart({ onSelectStatus }: Props) {
+  const chartRef = useRef<HTMLDivElement>(null);
   const data = useMemo(() => {
     return actions.reduce<StatusCount[]>((acc, action: Action) => {
       const found = acc.find((item) => item.status === action.status);
@@ -32,22 +34,48 @@ export default function ActionStatusPieChart({ onSelectStatus }: Props) {
   };
 
   return (
-    <div className="w-full min-w-0 h-48 md:h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
-      <ResponsiveContainer>
-        <PieChart>
-          <Pie data={data} dataKey="value" nameKey="status" label>
-            {data.map((entry) => (
-              <Cell
-                key={entry.status}
-                cursor="pointer"
-                fill={colorMap[entry.status] || '#8884d8'}
-                onClick={() => onSelectStatus(entry.status)}
-              />
-            ))}
-          </Pie>
-          <Tooltip />
-        </PieChart>
-      </ResponsiveContainer>
+    <div className="w-full min-w-0 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
+      <div className="flex gap-2 mb-2">
+        <button
+          onClick={() =>
+            chartRef.current && exportElementToPDF(chartRef.current, 'actions.pdf')
+          }
+          className="px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded"
+        >
+          Export PDF
+        </button>
+        <button
+          onClick={() =>
+            chartRef.current && exportElementToPNG(chartRef.current, 'actions.png')
+          }
+          className="px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded"
+        >
+          Export PNG
+        </button>
+        <button
+          onClick={() => exportToCSV(data, 'actions.csv')}
+          className="px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded"
+        >
+          Export CSV
+        </button>
+      </div>
+      <div ref={chartRef} className="h-48 md:h-64">
+        <ResponsiveContainer>
+          <PieChart>
+            <Pie data={data} dataKey="value" nameKey="status" label>
+              {data.map((entry) => (
+                <Cell
+                  key={entry.status}
+                  cursor="pointer"
+                  fill={colorMap[entry.status] || '#8884d8'}
+                  onClick={() => onSelectStatus(entry.status)}
+                />
+              ))}
+            </Pie>
+            <Tooltip />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/IncidentTable.tsx
+++ b/frontend/src/components/IncidentTable.tsx
@@ -1,9 +1,10 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useState, useRef } from 'react';
 import { useTable, useGlobalFilter, Column } from 'react-table';
 import type { Incident } from '../types';
 import { useIncidents } from '../services/api';
 import LoadingSpinner from './LoadingSpinner';
 import ErrorMessage from './ErrorMessage';
+import { exportElementToPDF, exportToCSV } from '../utils/export';
 
 interface Props {
   severityFilter?: string;
@@ -20,6 +21,7 @@ export default function IncidentTable({ severityFilter }: Props) {
   const [service, setService] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const tableRef = useRef<HTMLTableElement>(null);
 
   const severityOptions = useMemo(
     () => Array.from(new Set(incidents.map((i) => i.severity))),
@@ -131,8 +133,25 @@ export default function IncidentTable({ severityFilter }: Props) {
           className="border border-neutral-300 dark:border-neutral-600 rounded p-1 bg-white dark:bg-neutral-800 text-neutral-900 dark:text-neutral-100"
         />
       </div>
+      <div className="flex gap-2">
+        <button
+          onClick={() =>
+            tableRef.current && exportElementToPDF(tableRef.current, 'incidents.pdf')
+          }
+          className="px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded"
+        >
+          Export PDF
+        </button>
+        <button
+          onClick={() => exportToCSV(data, 'incidents.csv')}
+          className="px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded"
+        >
+          Export CSV
+        </button>
+      </div>
       <div className="overflow-x-auto">
         <table
+          ref={tableRef}
           {...getTableProps()}
           className="min-w-full border border-neutral-300 dark:border-neutral-700 bg-white dark:bg-neutral-800 rounded text-xs sm:text-sm"
         >

--- a/frontend/src/components/SeverityBarChart.tsx
+++ b/frontend/src/components/SeverityBarChart.tsx
@@ -1,7 +1,8 @@
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import type { Incident } from '../types';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, useRef } from 'react';
 import { fetchIncidents } from '../services/incidents';
+import { exportElementToPDF, exportElementToPNG, exportToCSV } from '../utils/export';
 
 interface Props {
   onSelectSeverity: (sev: string) => void;
@@ -14,6 +15,7 @@ interface SeverityCount {
 
 export default function SeverityBarChart({ onSelectSeverity }: Props) {
   const [incidents, setIncidents] = useState<Incident[]>([]);
+  const chartRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetchIncidents().then(setIncidents).catch(() => setIncidents([]));
@@ -38,24 +40,50 @@ export default function SeverityBarChart({ onSelectSeverity }: Props) {
   };
 
   return (
-    <div className="w-full min-w-0 h-48 md:h-64 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
-      <ResponsiveContainer>
-        <BarChart data={data}>
-          <XAxis dataKey="severity" />
-          <YAxis allowDecimals={false} />
-          <Tooltip />
-          <Bar dataKey="count">
-            {data.map((entry) => (
-              <Cell
-                key={entry.severity}
-                cursor="pointer"
-                fill={colorMap[entry.severity] || '#8884d8'}
-                onClick={() => onSelectSeverity(entry.severity)}
-              />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
+    <div className="w-full min-w-0 p-4 bg-white dark:bg-neutral-800 border border-neutral-200 dark:border-neutral-700 rounded">
+      <div className="flex gap-2 mb-2">
+        <button
+          onClick={() =>
+            chartRef.current && exportElementToPDF(chartRef.current, 'severity.pdf')
+          }
+          className="px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded"
+        >
+          Export PDF
+        </button>
+        <button
+          onClick={() =>
+            chartRef.current && exportElementToPNG(chartRef.current, 'severity.png')
+          }
+          className="px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded"
+        >
+          Export PNG
+        </button>
+        <button
+          onClick={() => exportToCSV(data, 'severity.csv')}
+          className="px-2 py-1 border border-neutral-300 dark:border-neutral-600 rounded"
+        >
+          Export CSV
+        </button>
+      </div>
+      <div ref={chartRef} className="h-48 md:h-64">
+        <ResponsiveContainer>
+          <BarChart data={data}>
+            <XAxis dataKey="severity" />
+            <YAxis allowDecimals={false} />
+            <Tooltip />
+            <Bar dataKey="count">
+              {data.map((entry) => (
+                <Cell
+                  key={entry.severity}
+                  cursor="pointer"
+                  fill={colorMap[entry.severity] || '#8884d8'}
+                  onClick={() => onSelectSeverity(entry.severity)}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/__tests__/ActionStatusPieChart.test.tsx
+++ b/frontend/src/components/__tests__/ActionStatusPieChart.test.tsx
@@ -3,6 +3,13 @@ import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import ActionStatusPieChart from '../ActionStatusPieChart';
 import ActionList from '../ActionList';
+import { exportElementToPDF, exportElementToPNG, exportToCSV } from '../../utils/export';
+
+jest.mock('../../utils/export', () => ({
+  exportElementToPDF: jest.fn(),
+  exportElementToPNG: jest.fn(),
+  exportToCSV: jest.fn(),
+}));
 
 function Wrapper() {
   const [status, setStatus] = useState<string | undefined>(undefined);
@@ -26,6 +33,17 @@ describe('ActionStatusPieChart', () => {
     expect(within(list).getAllByRole('listitem')).toHaveLength(2);
     expect(within(list).queryByText(/In Progress/)).toBeNull();
     expect(within(list).queryByText(/Closed/)).toBeNull();
+  });
+
+  it('exports chart', async () => {
+    const user = userEvent.setup();
+    render(<ActionStatusPieChart onSelectStatus={jest.fn()} />);
+    await user.click(screen.getByRole('button', { name: /export pdf/i }));
+    expect(exportElementToPDF).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /export png/i }));
+    expect(exportElementToPNG).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /export csv/i }));
+    expect(exportToCSV).toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components/__tests__/IncidentTable.test.tsx
+++ b/frontend/src/components/__tests__/IncidentTable.test.tsx
@@ -3,8 +3,13 @@ import userEvent from '@testing-library/user-event';
 import IncidentTable from '../IncidentTable';
 import { useIncidents } from '../../services/api';
 import mockIncidents from '../../utils/mock/incidents.json';
+import { exportElementToPDF, exportToCSV } from '../../utils/export';
 
 jest.mock('../../services/api', () => ({ useIncidents: jest.fn() }));
+jest.mock('../../utils/export', () => ({
+  exportElementToPDF: jest.fn(),
+  exportToCSV: jest.fn(),
+}));
 
 describe('IncidentTable', () => {
   beforeEach(() => {
@@ -42,6 +47,16 @@ describe('IncidentTable', () => {
     const table = screen.getByRole('table');
     expect(within(table).getAllByRole('row')).toHaveLength(2);
     expect(within(table).getByText('6')).toBeInTheDocument();
+  });
+
+  it('exports data', async () => {
+    const user = userEvent.setup();
+    render(<IncidentTable />);
+    await screen.findByText('Auth');
+    await user.click(screen.getByRole('button', { name: /export pdf/i }));
+    expect(exportElementToPDF).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /export csv/i }));
+    expect(exportToCSV).toHaveBeenCalled();
   });
 });
 

--- a/frontend/src/components/__tests__/SeverityBarChart.test.tsx
+++ b/frontend/src/components/__tests__/SeverityBarChart.test.tsx
@@ -5,8 +5,14 @@ import SeverityBarChart from '../SeverityBarChart';
 import IncidentTable from '../IncidentTable';
 import { fetchIncidents } from '../../services/incidents';
 import mockIncidents from '../../utils/mock/incidents.json';
+import { exportElementToPDF, exportElementToPNG, exportToCSV } from '../../utils/export';
 
 jest.mock('../../services/incidents');
+jest.mock('../../utils/export', () => ({
+  exportElementToPDF: jest.fn(),
+  exportElementToPNG: jest.fn(),
+  exportToCSV: jest.fn(),
+}));
 
 function Wrapper() {
   const [severity, setSeverity] = useState<string | undefined>(undefined);
@@ -35,5 +41,21 @@ describe('SeverityBarChart', () => {
     const table = screen.getByRole('table');
     expect(within(table).getAllByRole('row')).toHaveLength(3);
     expect(within(table).queryByText('SEV-2')).toBeNull();
+  });
+
+  it('exports chart', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <SeverityBarChart onSelectSeverity={jest.fn()} />
+    );
+    await waitFor(() => {
+      expect(container.querySelectorAll('.recharts-bar-rectangle').length).toBeGreaterThan(0);
+    });
+    await user.click(screen.getByRole('button', { name: /export pdf/i }));
+    expect(exportElementToPDF).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /export png/i }));
+    expect(exportElementToPNG).toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /export csv/i }));
+    expect(exportToCSV).toHaveBeenCalled();
   });
 });

--- a/frontend/src/utils/export.ts
+++ b/frontend/src/utils/export.ts
@@ -1,0 +1,31 @@
+import { jsPDF } from 'jspdf';
+import html2canvas from 'html2canvas';
+import Papa from 'papaparse';
+
+export async function exportElementToPDF(element: HTMLElement, filename: string) {
+  const canvas = await html2canvas(element);
+  const imgData = canvas.toDataURL('image/png');
+  const pdf = new jsPDF('l', 'pt', [canvas.width, canvas.height]);
+  pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+  pdf.save(filename);
+}
+
+export async function exportElementToPNG(element: HTMLElement, filename: string) {
+  const canvas = await html2canvas(element);
+  const dataUrl = canvas.toDataURL('image/png');
+  const link = document.createElement('a');
+  link.href = dataUrl;
+  link.download = filename;
+  link.click();
+}
+
+export function exportToCSV(data: object[], filename: string) {
+  const csv = Papa.unparse(data);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add export helpers for PDF/PNG and CSV generation
- enable exporting incidents table and charts
- test export button interactions

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02b41d8348329bad9547ebe478f55