### PR TITLE
Add timeline endpoint with category filtering

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import postmortems from './routes/postmortems';
 import actions from './routes/actions';
 import metrics from './routes/metrics';
 import summary from './routes/summary';
+import timeline from './routes/timeline';
 import authRoutes from './routes/auth';
 import authMiddleware from './middleware/auth';
 import shareRoutes from './routes/share';
@@ -34,6 +35,7 @@ app.use('/postmortems', shareAuth, postmortems);
 app.use('/actions', authMiddleware, rbac(['admin']), actions);
 app.use('/metrics', authMiddleware, rbac(['admin']), metrics);
 app.use('/summary', authMiddleware, summary);
+app.use('/timeline', shareAuth, timeline);
 
 const schema = buildSchema(`
   type Postmortem {

--- a/backend/src/routes/timeline.ts
+++ b/backend/src/routes/timeline.ts
@@ -1,0 +1,29 @@
+import { Router } from 'express';
+import { collectTimelineEvents } from '../../../integrations/src/timeline';
+import { createIntegrations } from '../../../integrations/src';
+
+const router = Router();
+
+router.get('/', async (req, res, next) => {
+  try {
+    const start = req.query.start ? new Date(req.query.start as string) : new Date(0);
+    const end = req.query.end ? new Date(req.query.end as string) : new Date();
+    const providers = typeof req.query.providers === 'string'
+      ? (req.query.providers as string).split(',')
+      : undefined;
+    const category = typeof req.query.category === 'string' ? (req.query.category as 'human' | 'system') : undefined;
+
+    const all = createIntegrations();
+    const selected = providers
+      ? Object.fromEntries(Object.entries(all).filter(([k]) => providers.includes(k)))
+      : all;
+
+    const events = await collectTimelineEvents(start, end, selected);
+    const filtered = category ? events.filter((e) => e.category === category) : events;
+    res.json({ events: filtered });
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,25 @@
+# API
+
+## GET /timeline
+
+Returns merged timeline events from connected integrations such as Slack, PagerDuty, and ServiceNow.
+
+### Query Parameters
+- `start`: ISO8601 timestamp to filter events after this time.
+- `end`: ISO8601 timestamp to filter events before this time.
+- `providers`: Comma-separated list of providers to include (`slack`, `pagerduty`, `servicenow`).
+- `category`: Filter by event category (`human` or `system`).
+
+### Response
+```json
+{
+  "events": [
+    {
+      "source": "slack",
+      "timestamp": "2024-01-01T00:00:00Z",
+      "description": "Message posted",
+      "category": "human"
+    }
+  ]
+}
+```

--- a/frontend/src/components/TimelineTab.tsx
+++ b/frontend/src/components/TimelineTab.tsx
@@ -6,6 +6,9 @@ export default function TimelineTab() {
   const [start, setStart] = useState('');
   const [end, setEnd] = useState('');
   const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
+  const [selectedCategories, setSelectedCategories] = useState<
+    ('human' | 'system')[]
+  >(['human', 'system']);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -31,12 +34,19 @@ export default function TimelineTab() {
     );
   };
 
+  const toggleCategory = (c: 'human' | 'system') => {
+    setSelectedCategories((prev) =>
+      prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]
+    );
+  };
+
   const filtered = events.filter((ev) => {
     const time = new Date(ev.timestamp).getTime();
     const s = start ? new Date(start).getTime() : -Infinity;
     const e = end ? new Date(end).getTime() : Infinity;
     return (
       selectedProviders.includes(ev.source) &&
+      selectedCategories.includes(ev.category) &&
       time >= s &&
       time <= e
     );
@@ -53,6 +63,7 @@ export default function TimelineTab() {
   };
 
   const providers = Array.from(new Set(events.map((e) => e.source)));
+  const categories: ('human' | 'system')[] = ['human', 'system'];
 
   return (
     <div className="space-y-4">
@@ -89,6 +100,18 @@ export default function TimelineTab() {
                 onChange={() => toggleProvider(p)}
               />
               {p}
+            </label>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          {categories.map((c) => (
+            <label key={c} className="flex items-center gap-1">
+              <input
+                type="checkbox"
+                checked={selectedCategories.includes(c)}
+                onChange={() => toggleCategory(c)}
+              />
+              {c.charAt(0).toUpperCase() + c.slice(1)}
             </label>
           ))}
         </div>

--- a/frontend/src/components/__tests__/PostmortemViewer.test.tsx
+++ b/frontend/src/components/__tests__/PostmortemViewer.test.tsx
@@ -25,7 +25,7 @@ jest.mock('html2canvas');
 describe('PostmortemViewer', () => {
   beforeEach(() => {
     (fetchTimelineEvents as jest.Mock).mockResolvedValue([
-      { source: 's', timestamp: 't', description: 'event' },
+      { source: 's', timestamp: 't', description: 'event', category: 'human' },
     ]);
     (loadActions as jest.Mock).mockReturnValue([
       { id: '1', provider: 'jira', description: 'action', url: 'u' },

--- a/frontend/src/components/__tests__/TimelineTab.test.tsx
+++ b/frontend/src/components/__tests__/TimelineTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import TimelineTab from '../TimelineTab';
 import { fetchTimelineEvents } from '../../services/timeline';
 
@@ -11,5 +11,23 @@ describe('TimelineTab', () => {
     render(<TimelineTab />);
 
     expect(await screen.findByRole('alert')).toHaveTextContent('failed to load');
+  });
+
+  it('filters events by category', async () => {
+    (fetchTimelineEvents as jest.Mock).mockResolvedValue([
+      { source: 'slack', timestamp: '2024-01-01T00:00:00Z', description: 'human event', category: 'human' },
+      { source: 'pagerduty', timestamp: '2024-01-01T01:00:00Z', description: 'system event', category: 'system' },
+    ]);
+
+    render(<TimelineTab />);
+
+    expect(await screen.findByText(/human event/)).toBeInTheDocument();
+    expect(screen.getByText(/system event/)).toBeInTheDocument();
+
+    const systemCheckbox = screen.getByLabelText('System');
+    fireEvent.click(systemCheckbox);
+
+    expect(screen.queryByText(/system event/)).not.toBeInTheDocument();
+    expect(screen.getByText(/human event/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,12 +8,14 @@ import PostmortemViewer from '../components/PostmortemViewer';
 import PostmortemSearch from '../components/PostmortemSearch';
 import ThemeToggle from '../components/ThemeToggle';
 import SummaryBanner from '../components/SummaryBanner';
+import TimelineTab from '../components/TimelineTab';
 import type { Postmortem } from '../types';
 const tabs = [
   'Incidents',
   'Postmortems',
   'Actions',
   'Metrics',
+  'Timeline',
 ] as const;
 type Tab = typeof tabs[number];
 
@@ -73,6 +75,11 @@ export default function Dashboard() {
         {active === 'Metrics' && (
           <div className="max-w-screen-xl mx-auto grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             <MetricsTab />
+          </div>
+        )}
+        {active === 'Timeline' && (
+          <div className="max-w-screen-xl mx-auto">
+            <TimelineTab />
           </div>
         )}
       </main>

--- a/frontend/src/services/ai/__tests__/narrative.test.ts
+++ b/frontend/src/services/ai/__tests__/narrative.test.ts
@@ -21,6 +21,7 @@ describe('narrative helpers', () => {
         source: 'monitor',
         timestamp: '2024-01-01T00:00:00Z',
         description: 'Alert triggered',
+        category: 'system',
       },
     ];
     (fetch as jest.Mock).mockResolvedValue({
@@ -69,6 +70,7 @@ describe('narrative helpers', () => {
         source: 'monitor',
         timestamp: '2024-01-01T00:00:00Z',
         description: 'Alert triggered',
+        category: 'system',
       },
     ];
     (fetch as jest.Mock)

--- a/frontend/src/services/timeline.ts
+++ b/frontend/src/services/timeline.ts
@@ -2,6 +2,7 @@ export interface TimelineEvent {
   source: string;
   timestamp: string;
   description: string;
+  category: 'human' | 'system';
 }
 
 import { config } from '../utils/config';
@@ -10,7 +11,8 @@ import mockEvents from '../utils/mock/timeline.json';
 export async function fetchTimelineEvents(
   start?: Date,
   end?: Date,
-  providers?: string[]
+  providers?: string[],
+  category?: 'human' | 'system'
 ): Promise<TimelineEvent[]> {
   if (config.useMockData) {
     let events = mockEvents as TimelineEvent[];
@@ -19,6 +21,9 @@ export async function fetchTimelineEvents(
     if (providers && providers.length) {
       events = events.filter((e) => providers.includes(e.source));
     }
+     if (category) {
+      events = events.filter((e) => e.category === category);
+    }
     return events;
   }
 
@@ -26,6 +31,7 @@ export async function fetchTimelineEvents(
   if (start) params.set('start', start.toISOString());
   if (end) params.set('end', end.toISOString());
   if (providers && providers.length) params.set('providers', providers.join(','));
+  if (category) params.set('category', category);
 
   const res = await fetch(`/timeline?${params.toString()}`);
   if (!res.ok) {

--- a/frontend/src/utils/mock/timeline.json
+++ b/frontend/src/utils/mock/timeline.json
@@ -2,16 +2,19 @@
   {
     "source": "monitoring",
     "timestamp": "2024-01-01T00:00:00Z",
-    "description": "Alert triggered"
+    "description": "Alert triggered",
+    "category": "system"
   },
   {
     "source": "incident",
     "timestamp": "2024-01-01T00:05:00Z",
-    "description": "Investigation started"
+    "description": "Investigation started",
+    "category": "human"
   },
   {
     "source": "resolution",
     "timestamp": "2024-01-01T00:30:00Z",
-    "description": "Issue resolved"
+    "description": "Issue resolved",
+    "category": "system"
   }
 ]

--- a/integrations/src/pagerDuty.ts
+++ b/integrations/src/pagerDuty.ts
@@ -32,7 +32,7 @@ export class PagerDutyIntegration implements Integration {
         end: end.toISOString(),
       },
     });
-    return data;
+    return (data as TimelineEvent[]).map((e) => ({ ...e, category: 'system' }));
   }
 }
 

--- a/integrations/src/serviceNow.ts
+++ b/integrations/src/serviceNow.ts
@@ -32,7 +32,7 @@ export class ServiceNowIntegration implements Integration {
         end: end.toISOString(),
       },
     });
-    return data;
+    return (data as TimelineEvent[]).map((e) => ({ ...e, category: 'system' }));
   }
 }
 

--- a/integrations/src/slack.ts
+++ b/integrations/src/slack.ts
@@ -32,6 +32,6 @@ export class SlackIntegration implements Integration {
         end: end.toISOString(),
       },
     });
-    return data;
+    return (data as TimelineEvent[]).map((e) => ({ ...e, category: 'human' }));
   }
 }

--- a/integrations/src/types.ts
+++ b/integrations/src/types.ts
@@ -19,6 +19,7 @@ export interface TimelineEvent {
   source: string;
   timestamp: string;
   description: string;
+  category: 'human' | 'system';
   [key: string]: any;
 }
 

--- a/plugins/datadog.ts
+++ b/plugins/datadog.ts
@@ -35,6 +35,7 @@ class DatadogIntegration implements Integration {
         source: 'Datadog',
         timestamp: start.toISOString(),
         description: 'Datadog event',
+        category: 'system',
       },
     ];
   }

--- a/plugins/grafana.ts
+++ b/plugins/grafana.ts
@@ -35,6 +35,7 @@ class GrafanaIntegration implements Integration {
         source: 'Grafana',
         timestamp: start.toISOString(),
         description: 'Grafana event',
+        category: 'system',
       },
     ];
   }

--- a/plugins/splunk.ts
+++ b/plugins/splunk.ts
@@ -35,6 +35,7 @@ class SplunkIntegration implements Integration {
         source: 'Splunk',
         timestamp: start.toISOString(),
         description: 'Splunk event',
+        category: 'system',
       },
     ];
   }

--- a/plugins/zoom.ts
+++ b/plugins/zoom.ts
@@ -35,6 +35,7 @@ class ZoomIntegration implements Integration {
         source: 'Zoom',
         timestamp: start.toISOString(),
         description: 'Zoom event',
+        category: 'human',
       },
     ];
   }


### PR DESCRIPTION
## Summary
- extend TimelineEvent with human/system category and tag Slack, PagerDuty, ServiceNow accordingly
- expose GET /timeline endpoint to aggregate events and filter by provider or category
- add Timeline tab to dashboard with category checkboxes and document new API

## Testing
- `npm run build` (backend) *(fails: Cannot find name 'process' and rootDir issues)*
- `npm test` (integrations) *(fails: TypeError: Converting circular structure to JSON)*
- `npm test` (frontend) *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b02f0ce7908329b6460a5b37d646bc