### PR TITLE
feat: add OpenAPI docs and Swagger UI

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1,0 +1,241 @@
+openapi: 3.0.3
+info:
+  title: Aftermath API
+  version: 1.0.0
+paths:
+  /incidents:
+    get:
+      summary: List incidents
+      responses:
+        '200':
+          description: A list of incidents
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  incidents:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Incident'
+  /incidents/{id}:
+    get:
+      summary: Get incident by ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Incident details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+  /postmortems:
+    post:
+      summary: Create a postmortem
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Postmortem'
+      responses:
+        '201':
+          description: Postmortem created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Postmortem'
+    get:
+      summary: List postmortems
+      responses:
+        '200':
+          description: A list of postmortems
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  postmortems:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Postmortem'
+  /postmortems/{id}:
+    get:
+      summary: Get postmortem by ID
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Postmortem details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Postmortem'
+    put:
+      summary: Update a postmortem
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Postmortem'
+      responses:
+        '200':
+          description: Postmortem updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Postmortem'
+  /actions:
+    post:
+      summary: Create an action
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Action'
+      responses:
+        '201':
+          description: Action created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Action'
+    get:
+      summary: List actions
+      responses:
+        '200':
+          description: A list of actions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Action'
+  /actions/{id}:
+    patch:
+      summary: Update action status
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  enum: [open, closed]
+      responses:
+        '200':
+          description: Action updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Action'
+  /metrics:
+    get:
+      summary: Get service metrics
+      responses:
+        '200':
+          description: Metrics summary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Metrics'
+components:
+  schemas:
+    Incident:
+      type: object
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        team:
+          type: string
+        status:
+          type: string
+          enum: [open, closed]
+        severity:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        resolvedAt:
+          type: string
+          format: date-time
+        slaHours:
+          type: integer
+      required: [id, title, team, status, severity, createdAt, slaHours]
+    Postmortem:
+      type: object
+      properties:
+        id:
+          type: integer
+        incidentId:
+          type: integer
+        summary:
+          type: string
+        completedAt:
+          type: string
+          format: date-time
+        tags:
+          type: array
+          items:
+            type: string
+      required: [id, incidentId, summary, completedAt, tags]
+    Action:
+      type: object
+      properties:
+        id:
+          type: integer
+        incidentId:
+          type: integer
+        description:
+          type: string
+        status:
+          type: string
+          enum: [open, closed]
+        createdAt:
+          type: string
+          format: date-time
+        closedAt:
+          type: string
+          format: date-time
+      required: [id, incidentId, description, status, createdAt]
+    Metrics:
+      type: object
+      properties:
+        mttrHours:
+          type: number
+        slaCompliance:
+          type: number
+          description: Percentage of incidents resolved within SLA
+        openActions:
+          type: integer
+      required: [mttrHours, slaCompliance, openActions]

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,9 @@
     "zod": "^3.22.4",
     "sqlite3": "^5.1.6",
     "express-graphql": "^0.12.0",
-    "graphql": "^16.8.1"
+    "graphql": "^16.8.1",
+    "swagger-ui-express": "^5.0.0",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
@@ -26,6 +28,8 @@
     "@types/jsonwebtoken": "^9.0.2",
     "@types/sqlite3": "^3.1.8",
     "@types/express-graphql": "^0.8.9",
+    "@types/swagger-ui-express": "^4.1.3",
+    "@types/yamljs": "^0.2.31",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.0"
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,7 @@
 import express from 'express';
+import path from 'path';
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yamljs';
 import incidents from './routes/incidents';
 import postmortems from './routes/postmortems';
 import actions from './routes/actions';
@@ -27,6 +30,9 @@ if (!process.env.JWT_SECRET) {
 
 app.use(express.json());
 app.use(logger);
+
+const swaggerDocument = YAML.load(path.join(__dirname, '../openapi.yaml'));
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
 app.use('/auth', authRoutes);
 app.use('/share', authMiddleware, shareRoutes);


### PR DESCRIPTION
## Summary
- document incidents, postmortems, actions and metrics endpoints with OpenAPI
- serve OpenAPI spec at `/docs` using Swagger UI
- add required swagger dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fbcryptjs)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'sqlite3')*


------
https://chatgpt.com/codex/tasks/task_e_68b045cebdc083298f0fad833556d1b6