### PR TITLE
feat: add database-backed metrics calculations

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -231,11 +231,21 @@ components:
     Metrics:
       type: object
       properties:
-        mttrHours:
+        mttrPerIncident:
+          type: array
+          items:
+            type: object
+            properties:
+              incidentId:
+                type: integer
+              mttrHours:
+                type: number
+            required: [incidentId, mttrHours]
+        avgMttrHours:
           type: number
         slaCompliance:
           type: number
           description: Percentage of incidents resolved within SLA
         openActions:
           type: integer
-      required: [mttrHours, slaCompliance, openActions]
+      required: [mttrPerIncident, avgMttrHours, slaCompliance, openActions]


### PR DESCRIPTION
## Summary
- compute MTTR, SLA compliance, and open actions from Postgres data
- document new metrics fields in OpenAPI spec

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Cannot find module 'pg' or its corresponding type declarations, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b07e2710348329bacf62b3a27d9fe8