### PR TITLE
feat: add mock data option

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,10 +2,6 @@ import express from 'express';
 import path from 'path';
 import swaggerUi from 'swagger-ui-express';
 import YAML from 'yamljs';
-import incidents from './routes/incidents';
-import postmortems from './routes/postmortems';
-import actions from './routes/actions';
-import metrics from './routes/metrics';
 import summary from './routes/summary';
 import timeline from './routes/timeline';
 import authRoutes from './routes/auth';
@@ -21,6 +17,21 @@ import { searchPostmortems } from './search';
 
 const app = express();
 const port = Number(process.env.PORT) || 5000;
+
+const useMockData = process.env.USE_MOCK_DATA === 'true';
+
+const incidents = (useMockData
+  ? require('./mock/incidents')
+  : require('./routes/incidents')).default;
+const postmortems = (useMockData
+  ? require('./mock/postmortems')
+  : require('./routes/postmortems')).default;
+const actions = (useMockData
+  ? require('./mock/actions')
+  : require('./routes/actions')).default;
+const metrics = (useMockData
+  ? require('./mock/metrics')
+  : require('./routes/metrics')).default;
 
 if (!process.env.JWT_SECRET) {
   // eslint-disable-next-line no-console

--- a/backend/src/mock/actions.ts
+++ b/backend/src/mock/actions.ts
@@ -1,0 +1,48 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import validate from '../middleware/validate';
+import { actions } from './data';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({ actions });
+});
+
+const actionSchema = z.object({
+  postmortem_id: z.number(),
+  description: z.string(),
+  owner: z.string(),
+  status: z.string(),
+  due_date: z.string().optional(),
+});
+
+router.post('/', validate(actionSchema), (req, res) => {
+  const id = actions.length ? Math.max(...actions.map((a) => a.id)) + 1 : 1;
+  const action = {
+    id,
+    postmortem_id: req.body.postmortem_id,
+    description: req.body.description,
+    owner: req.body.owner,
+    status: req.body.status,
+    due_date: req.body.due_date ? new Date(req.body.due_date) : null,
+  };
+  actions.push(action);
+  res.status(201).json(action);
+});
+
+const statusSchema = z.object({
+  status: z.string(),
+});
+
+router.patch('/:id', validate(statusSchema), (req, res) => {
+  const action = actions.find((a) => a.id === Number(req.params.id));
+  if (!action) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  action.status = req.body.status;
+  res.json(action);
+});
+
+export default router;

--- a/backend/src/mock/data.ts
+++ b/backend/src/mock/data.ts
@@ -1,0 +1,77 @@
+export interface Incident {
+  id: number;
+  title: string;
+  service: string;
+  severity: number;
+  status: string;
+  date_detected: Date;
+  date_resolved: Date | null;
+  sla_hours: number | null;
+}
+
+export interface Postmortem {
+  id: number;
+  incident_id: number;
+  summary: string | null;
+  impact: string | null;
+  root_cause: string | null;
+  resolution: string | null;
+  timeline: any | null;
+  lessons: string | null;
+}
+
+export interface Action {
+  id: number;
+  postmortem_id: number;
+  description: string;
+  owner: string;
+  status: string;
+  due_date: Date | null;
+}
+
+export const incidents: Incident[] = [
+  {
+    id: 1,
+    title: 'Database outage',
+    service: 'database',
+    severity: 1,
+    status: 'resolved',
+    date_detected: new Date('2023-01-01T00:00:00Z'),
+    date_resolved: new Date('2023-01-01T02:00:00Z'),
+    sla_hours: 4,
+  },
+  {
+    id: 2,
+    title: 'API latency spike',
+    service: 'api',
+    severity: 2,
+    status: 'open',
+    date_detected: new Date('2023-02-01T00:00:00Z'),
+    date_resolved: null,
+    sla_hours: 2,
+  },
+];
+
+export const postmortems: Postmortem[] = [
+  {
+    id: 1,
+    incident_id: 1,
+    summary: 'Outage caused by misconfiguration',
+    impact: 'Service unavailable',
+    root_cause: 'Incorrect settings',
+    resolution: 'Reverted configuration',
+    timeline: null,
+    lessons: 'Improve change review',
+  },
+];
+
+export const actions: Action[] = [
+  {
+    id: 1,
+    postmortem_id: 1,
+    description: 'Add config validation',
+    owner: 'alice',
+    status: 'open',
+    due_date: null,
+  },
+];

--- a/backend/src/mock/incidents.ts
+++ b/backend/src/mock/incidents.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { incidents } from './data';
+
+const router = Router();
+
+router.get('/', (_req, res) => {
+  res.json({ incidents });
+});
+
+router.get('/:id', (req, res) => {
+  const incident = incidents.find((i) => i.id === Number(req.params.id));
+  if (!incident) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  res.json(incident);
+});
+
+export default router;

--- a/backend/src/mock/metrics.ts
+++ b/backend/src/mock/metrics.ts
@@ -1,0 +1,43 @@
+import { Router } from 'express';
+import { incidents, actions } from './data';
+
+const router = Router();
+
+const MS_IN_HOUR = 1000 * 60 * 60;
+
+router.get('/', (_req, res) => {
+  const mttrPerIncident = incidents
+    .filter((i) => i.date_resolved)
+    .map((i) => ({
+      incidentId: i.id,
+      mttrHours:
+        (i.date_resolved!.getTime() - i.date_detected.getTime()) / MS_IN_HOUR,
+    }));
+
+  const avgMttrHours = mttrPerIncident.length
+    ? mttrPerIncident.reduce((sum, i) => sum + i.mttrHours, 0) /
+      mttrPerIncident.length
+    : 0;
+
+  const slaMet = incidents.filter(
+    (i) =>
+      i.date_resolved &&
+      i.sla_hours !== null &&
+      i.date_resolved.getTime() - i.date_detected.getTime() <=
+        (i.sla_hours || 0) * MS_IN_HOUR
+  ).length;
+  const slaCompliance = incidents.length
+    ? (slaMet / incidents.length) * 100
+    : 0;
+
+  const openActions = actions.filter((a) => a.status !== 'closed').length;
+
+  res.json({
+    mttrPerIncident,
+    avgMttrHours,
+    slaCompliance,
+    openActions,
+  });
+});
+
+export default router;

--- a/backend/src/mock/postmortems.ts
+++ b/backend/src/mock/postmortems.ts
@@ -1,0 +1,58 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import validate from '../middleware/validate';
+import { postmortems } from './data';
+
+const router = Router();
+
+router.get('/search', (req, res) => {
+  const q = typeof req.query.q === 'string' ? req.query.q.toLowerCase() : '';
+  const results = postmortems.filter((p) =>
+    (p.summary || '').toLowerCase().includes(q)
+  );
+  res.json({ postmortems: results });
+});
+
+const postmortemSchema = z.object({
+  incident_id: z.number(),
+  summary: z.string().optional(),
+  impact: z.string().optional(),
+  root_cause: z.string().optional(),
+  resolution: z.string().optional(),
+  timeline: z.unknown().optional(),
+  lessons: z.string().optional(),
+});
+
+router.post('/', validate(postmortemSchema), (req, res) => {
+  const id = postmortems.length
+    ? Math.max(...postmortems.map((p) => p.id)) + 1
+    : 1;
+  const postmortem = { id, ...req.body };
+  postmortems.push(postmortem);
+  res.status(201).json(postmortem);
+});
+
+router.get('/:id', (req, res) => {
+  const postmortem = postmortems.find((p) => p.id === Number(req.params.id));
+  if (!postmortem) {
+    res.status(404).json({ error: 'Not found' });
+    return;
+  }
+  res.json(postmortem);
+});
+
+router.put(
+  '/:id',
+  validate(postmortemSchema.partial()),
+  (req, res) => {
+    const postmortem = postmortems.find((p) => p.id === Number(req.params.id));
+    if (!postmortem) {
+      res.status(404).json({ error: 'Not found' });
+      return;
+    }
+    Object.assign(postmortem, req.body);
+    res.json(postmortem);
+  }
+);
+
+export default router;


### PR DESCRIPTION
## Summary
- add USE_MOCK_DATA env flag to switch between mock and real models
- provide in-memory mock implementations for incidents, postmortems, actions, and metrics

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find module 'pg' or its corresponding type declarations)

------
https://chatgpt.com/codex/tasks/task_e_68b07f6380548329a06f25b1eecbe8dd