### PR TITLE
Expand role-based access control

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -49,8 +49,8 @@ app.use('/auth', authRoutes);
 app.use('/share', authMiddleware, shareRoutes);
 app.use('/incidents', shareAuth, incidents);
 app.use('/postmortems', shareAuth, postmortems);
-app.use('/actions', authMiddleware, rbac(['admin']), actions);
-app.use('/metrics', authMiddleware, rbac(['admin']), metrics);
+app.use('/actions', authMiddleware, rbac(['sre']), actions);
+app.use('/metrics', authMiddleware, rbac(['manager']), metrics);
 app.use('/summary', authMiddleware, summary);
 app.use('/timeline', shareAuth, timeline);
 

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -1,10 +1,12 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
 
+export type Role = 'admin' | 'sre' | 'manager' | 'executive';
+
 export interface UserPayload {
   id: number;
   username: string;
-  role: string;
+  role: Role;
 }
 
 export interface AuthRequest extends Request {

--- a/backend/src/middleware/rbac.ts
+++ b/backend/src/middleware/rbac.ts
@@ -1,12 +1,25 @@
 import { Response, NextFunction } from 'express';
-import { AuthRequest } from './auth';
+import { AuthRequest, Role } from './auth';
 
-export default function rbac(roles: string[]) {
+const hierarchy: Role[] = ['executive', 'manager', 'sre', 'admin'];
+
+export default function rbac(required: Role[]) {
   return (req: AuthRequest, res: Response, next: NextFunction) => {
     const user = req.user;
-    if (!user || !roles.includes(user.role)) {
+    if (!user) {
       return res.status(403).json({ message: 'Forbidden' });
     }
+
+    const userRank = hierarchy.indexOf(user.role as Role);
+    if (userRank === -1) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const allowed = required.some(role => userRank >= hierarchy.indexOf(role));
+    if (!allowed) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+
     next();
   };
 }

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -3,11 +3,12 @@ import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import { z } from 'zod';
 import validate from '../middleware/validate';
+import { Role } from '../middleware/auth';
 
 const router = Router();
 
 // Example in-memory users. In a real app, replace with DB lookup.
-const users = [
+const users: { id: number; username: string; passwordHash: string; role: Role }[] = [
   {
     id: 1,
     username: 'admin',
@@ -16,9 +17,21 @@ const users = [
   },
   {
     id: 2,
-    username: 'user',
+    username: 'sre',
     passwordHash: bcrypt.hashSync('password', 10),
-    role: 'user'
+    role: 'sre'
+  },
+  {
+    id: 3,
+    username: 'manager',
+    passwordHash: bcrypt.hashSync('password', 10),
+    role: 'manager'
+  },
+  {
+    id: 4,
+    username: 'executive',
+    passwordHash: bcrypt.hashSync('password', 10),
+    role: 'executive'
   }
 ];
 

--- a/docs/roles.md
+++ b/docs/roles.md
@@ -2,10 +2,17 @@
 
 After authentication, JSON Web Tokens include a `role` claim used by the frontend to decide which dashboard to render.
 
-## admin (SRE)
+## admin
+- Full access to all dashboards and administrative APIs.
+
+## sre
 - Access to the SRE dashboard
 - Views operational metrics, MTTR charts, and timeline information
 
-## user (Executive)
+## manager
+- Access to management dashboards
+- Views team performance metrics and reports
+
+## executive
 - Access to the executive dashboard
 - Sees high-level KPIs, SLA summaries, and status charts


### PR DESCRIPTION
## Summary
- add in-memory user roles for admin, sre, manager, and executive
- implement hierarchical RBAC middleware and update route protection
- document access levels for new roles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find name 'process')

------
https://chatgpt.com/codex/tasks/task_e_68b0817bcb40832996679a09bdfc0221